### PR TITLE
[#13] feat: 칵테일 관련 api 추가, 수정

### DIFF
--- a/src/main/java/com/application/domain/cocktail/controller/CocktailV2Controller.java
+++ b/src/main/java/com/application/domain/cocktail/controller/CocktailV2Controller.java
@@ -167,12 +167,30 @@ public class CocktailV2Controller implements CocktailV2ControllerDocs{
      */
     @Operation(summary = "칵테일 상세 조회", description = "칵테일 상세 정보를 조회합니다.")
     @GetMapping("/detail")
-    public ResponseEntity<ResponseDto<CocktailResponseDto>> getCocktail(@RequestParam Long cocktailId){
+    public ResponseEntity<ResponseDto<CocktailResponseDto>> getCocktail(
+            @Parameter(example = "1")
+            @RequestParam Long cocktailId
+    ){
 
         CocktailResponseDto cocktail = cocktailService.getCocktailV2(cocktailId);
 
         return new ResponseEntity<>(
                 ResponseDto.onSuccess("칵테일 조회 성공 (v2)", cocktail),
+                HttpStatus.OK
+        );
+    }
+
+    @Operation(summary = "칵테일 연관검색어 v2", description = "searchText에 따라 칵테일 이름을 조회합니다.")
+    @GetMapping("/suggestions")
+    public ResponseEntity<ResponseDto<List<String>>> getCocktailSuggestions(
+            @Parameter(example = "아")
+            @RequestParam String searchText
+    ){
+
+        List<String> cocktailSuggestions = cocktailService.getCocktailSuggestions(searchText);
+
+        return new ResponseEntity<>(
+                ResponseDto.onSuccess("칵테일 연관검색어 조회 성공 (v2)", cocktailSuggestions),
                 HttpStatus.OK
         );
     }

--- a/src/main/java/com/application/domain/cocktail/controller/CocktailV2Controller.java
+++ b/src/main/java/com/application/domain/cocktail/controller/CocktailV2Controller.java
@@ -166,8 +166,8 @@ public class CocktailV2Controller implements CocktailV2ControllerDocs{
      * @return
      */
     @Operation(summary = "칵테일 상세 조회", description = "칵테일 상세 정보를 조회합니다.")
-    @GetMapping("/{cocktailId}")
-    public ResponseEntity<ResponseDto<CocktailResponseDto>> getCocktail(@PathVariable Long cocktailId){
+    @GetMapping("/detail")
+    public ResponseEntity<ResponseDto<CocktailResponseDto>> getCocktail(@RequestParam Long cocktailId){
 
         CocktailResponseDto cocktail = cocktailService.getCocktailV2(cocktailId);
 

--- a/src/main/java/com/application/domain/cocktail/dto/response/CocktailResponseDto.java
+++ b/src/main/java/com/application/domain/cocktail/dto/response/CocktailResponseDto.java
@@ -6,6 +6,7 @@ import com.application.domain.cocktail.entity.CocktailMood;
 import com.application.domain.cocktail.enums.AbvLevel;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -27,9 +28,19 @@ public record CocktailResponseDto(
         Integer minAlcohol,
         String originText,
         String season,
-        String ingredientsText,
+
+        // 프론트 요구사항에 맞게 배열로 응답하도록 수정
+//        String ingredientsText,
+        List<String> ingredients,
+
         String style,
+
+        // glassType이 여러 개가 있는 칵테일이 있어 수정 -> 다시 원복
         String glassType,
+//        @Schema(description = "사용되는 글라스 타입 목록", example = "[\"칵테일 글라스\", \"마티니 글라스\"]")
+//        List<String> glassTypes,
+
+        String glassImageUrl,
         String base,
 
         String imageUrl,
@@ -45,6 +56,23 @@ public record CocktailResponseDto(
 ) {
     // 엔티티를 DTO로 변환하는 정적 팩토리 메서드는 record에서도 유효합니다.
     public static CocktailResponseDto from(Cocktail cocktail) {
+
+//        String rawGlassType = cocktail.getGlassType();
+//        // glassType 문자열을 '/' 기준으로 분리하여 List로 변환
+//        List<String> splitGlassTypes = (rawGlassType != null && !rawGlassType.isEmpty())
+//                ? Arrays.stream(rawGlassType.split("/"))
+//                .map(String::trim) // 공백 제거
+//                .toList()
+//                : List.of(); // 값이 없으면 빈 리스트 반환
+
+        // 재료 리스트로 전달하도록 수정
+        String rawIngredientsText = cocktail.getIngredientsText();
+        List<String> ingredients = (rawIngredientsText != null && !rawIngredientsText.isEmpty())
+                ? Arrays.stream(rawIngredientsText.split(","))
+                .map(String::trim) // 공백 제거
+                .toList()
+                : List.of(); // 값이 없으면 빈 리스트 반환
+
         return new CocktailResponseDto(
                 cocktail.getId(),
                 cocktail.getKorName(),
@@ -54,9 +82,17 @@ public record CocktailResponseDto(
                 cocktail.getMinAlcohol(),
                 cocktail.getOriginText(),
                 cocktail.getSeason(),
-                cocktail.getIngredientsText(),
+
+                // 재료 list로 변경에 따른 수정
+                ingredients,
+//                cocktail.getIngredientsText(),
+
                 cocktail.getStyle(),
-                cocktail.getGlassType(),
+
+                cocktail.getGlassType(), // 잔 list로 변경에 따른 수정 -> 원복
+//                splitGlassTypes,
+
+                cocktail.getGlassImageUrl(),
                 cocktail.getBase(),
 
                 cocktail.getImageUrl(),

--- a/src/main/java/com/application/domain/cocktail/entity/Cocktail.java
+++ b/src/main/java/com/application/domain/cocktail/entity/Cocktail.java
@@ -85,6 +85,8 @@ public class Cocktail {
     // FIXME ENUM으로 하면 좋을듯
     private String glassType;
 
+    private String glassImageUrl;
+
     // FIXME ENUM으로 하면 좋을듯
     private String base;
 

--- a/src/main/java/com/application/domain/cocktail/repository/CocktailRepository.java
+++ b/src/main/java/com/application/domain/cocktail/repository/CocktailRepository.java
@@ -8,9 +8,20 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 
 @Repository
 public interface CocktailRepository extends JpaRepository<Cocktail, Long>, CocktailRepositoryCustom {
+
+    /**
+     * <pre>
+     *     [JpaRepository 메서드 쿼리]
+     *     특정 문자열로 시작하는 칵테일 최대 5개 조회
+     * </pre>
+     * @param searchText 검색어
+     */
+    List<CocktailNameProjection> findTop5ByKorNameStartingWith(String searchText);
 
     // 동시성을 고려한 Atomic 증가
 
@@ -33,4 +44,12 @@ public interface CocktailRepository extends JpaRepository<Cocktail, Long>, Cockt
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Cocktail c SET c.hardCount = c.hardCount - 1 WHERE c.id = :id")
     void decrementHard(@Param("id") Long id);
+
+    /**
+     * 칵테일 이름(korName)만 가져오기 위한 Projection Interface
+     * get필드명() 메서드를 정의하면 JPA가 해당 필드만 SELECT하여 채워줍니다.
+     */
+    interface CocktailNameProjection {
+        String getKorName();
+    }
 }

--- a/src/main/java/com/application/domain/cocktail/service/CocktailService.java
+++ b/src/main/java/com/application/domain/cocktail/service/CocktailService.java
@@ -159,6 +159,17 @@ public class CocktailService {
         return CocktailResponseDto.from(cocktail);
     }
 
+    public List<String> getCocktailSuggestions(String searchText){
+
+        List<CocktailRepository.CocktailNameProjection> projections =
+                cocktailRepository.findTop5ByKorNameStartingWith(searchText);
+
+        return projections.stream()
+                // CocktailNameProjection 객체에서 getKorName()을 호출하여 String을 얻음
+                .map(CocktailRepository.CocktailNameProjection::getKorName)
+                .toList();
+    }
+
     // ======================================================================================
 
     public CocktailDto getCocktailInfo(Long cocktailId){


### PR DESCRIPTION
## 📌 작업 개요
# 이슈번호
- #13 

## ✨ 기타 참고 사항
- 칵테일 응답 변경
  - 재료 list로 응답하도록 수정
  - 잔 이미지 url 응답하도록 수정
- 칵테일 상세조회 uri 변경
  - cocktails/1 -> cocktails/detail?cocktailId=1 로 변경
- 칵테일 연관검색어 api 추가

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 이슈번호가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.