### PR TITLE
[#53] fix: 화이트리스트 방식에 맞춰 spring security 수정

### DIFF
--- a/src/main/java/com/application/common/auth/config/SecurityConfig.java
+++ b/src/main/java/com/application/common/auth/config/SecurityConfig.java
@@ -90,9 +90,9 @@ public class SecurityConfig {
                         // swagger
                         .requestMatchers(SWAGGER_URLS).permitAll()
                         .requestMatchers("/webjars/**", "/favicon.ico").permitAll()
-                        // onz_v2
-//                        .requestMatchers("/api/v2/**").permitAll()
-//                        .requestMatchers("/onz/api/v2/**").permitAll()
+                        // onz_v2 - JWT 필터 화이트리스트 방식에 맞춰 v2 API는 기본 허용
+                        .requestMatchers("/api/v2/**").permitAll()
+                        .requestMatchers("/onz/api/v2/**").permitAll()
                         .anyRequest().authenticated());
 
         http


### PR DESCRIPTION
## 📌 작업 개요
  - JWT 필터가 화이트리스트 방식으로 변경되었으나, Spring Security 설정이 기존 방식(기본 차단)으로 남아있어 v2 API에서 403 에러가 발생하던 문제를 해결
  - SecurityConfig에 v2 API 경로를 `permitAll()`로 설정하여 JWT 필터의 화이트리스트 방식과 동기화
 - `SecurityConfig.java`: `/api/v2/**`, `/onz/api/v2/**` 경로를 `permitAll()`로 설정 (주석 해제)

## 이슈번호
- #53

## ✨ 기타 참고 사항

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 이슈번호가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.
