### PR TITLE
[#56] fix: 회원 탈퇴 시 monitoring 외래키 제약조건으로 인해 삭제 안되는 오류 해결

### DIFF
--- a/src/main/java/com/application/common/auth/controller/AuthController.java
+++ b/src/main/java/com/application/common/auth/controller/AuthController.java
@@ -22,9 +22,44 @@ public class AuthController {
      */
     @Operation(
             summary = "소셜 로그인 요청",
-            description = "소셜 플랫폼(카카오, 네이버, 애플 등)에서 받은 인증 코드 또는 액세스 토큰을 이용해 로그인합니다. " +
-                    "**기존 회원**이면 JWT 토큰 쌍(accessToken, refreshToken)을 반환하고, " +
-                    "**신규 회원**이면 회원가입을 위한 임시 코드(code)를 반환합니다."
+            description = """
+                    소셜 플랫폼(카카오, 네이버, 애플, 구글)에서 받은 인증 코드 또는 액세스 토큰을 이용해 로그인합니다.
+
+                    ## 응답 유형
+                    - **기존 회원**: JWT 토큰 쌍(accessToken, refreshToken)을 반환 (type: "token")
+                    - **신규 회원**: 회원가입을 위한 임시 코드를 반환 (type: "signup")
+
+                    ## 사용 방식
+
+                    ### 1️⃣ 모바일 앱 방식 (권장)
+                    React Native, Flutter 등 모바일 앱에서 네이버/카카오/구글 SDK를 사용하는 경우
+                    ```json
+                    {
+                      "provider": "naver",
+                      "accessToken": "AAAANvMf...SDK에서_받은_토큰"
+                    }
+                    ```
+
+                    ### 2️⃣ 웹 OAuth 방식
+                    웹에서 OAuth 리다이렉트 콜백을 받는 경우
+
+                    **네이버 (state 필요):**
+                    ```json
+                    {
+                      "provider": "naver",
+                      "code": "authorization_code",
+                      "state": "csrf_state_value"
+                    }
+                    ```
+
+                    **카카오/구글 (state 불필요):**
+                    ```json
+                    {
+                      "provider": "kakao",
+                      "code": "authorization_code"
+                    }
+                    ```
+                    """
     )
     @PostMapping("/social-login")
     public ResponseEntity<ResSocialLoginDto> socialLogin(@RequestBody ReqSocialLoginDto dto) {

--- a/src/main/java/com/application/common/auth/dto/login/ReqSocialLoginDto.java
+++ b/src/main/java/com/application/common/auth/dto/login/ReqSocialLoginDto.java
@@ -6,23 +6,33 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
-@Schema(description = "소셜 로그인 요청 DTO")
+@Schema(description = "소셜 로그인 요청 DTO - 모바일 앱 방식과 웹 OAuth 방식 모두 지원")
 public class ReqSocialLoginDto {
     @NotNull
     @JsonProperty("provider")
-    @Schema(description = "소셜 로그인 제공자 (kakao, naver, apple, google)", example = "kakao")
+    @Schema(description = "소셜 로그인 제공자",
+            example = "naver",
+            allowableValues = {"kakao", "naver", "apple", "google"})
     private String provider;
 
     @JsonProperty("code")
-    @Schema(description = "소셜 플랫폼에서 발급받은 인증 코드 (code 또는 accessToken 중 하나 필수)", example = "authorization_code_from_provider")
+    @Schema(description = "[웹 OAuth 방식] 소셜 플랫폼에서 발급받은 인증 코드. " +
+            "웹 OAuth 리다이렉트 콜백으로 받은 authorization code를 전달합니다. " +
+            "모바일 앱 방식에서는 사용하지 않습니다.",
+            example = "authorization_code_from_provider")
     private String code;
 
     @JsonProperty("state")
-    @Schema(description = "CSRF 방지를 위한 state 값 (네이버 로그인 시 필요)", example = "random_state_string")
+    @Schema(description = "[웹 OAuth 방식 - 네이버만 해당] CSRF 방지를 위한 state 값. " +
+            "네이버 웹 OAuth 사용 시에만 필요하며, 모바일 앱 방식에서는 사용하지 않습니다.",
+            example = "random_state_string")
     private String state;
 
     @JsonProperty("accessToken")
-    @Schema(description = "소셜 플랫폼에서 발급받은 액세스 토큰 (code 또는 accessToken 중 하나 필수)", example = "access_token_from_provider")
+    @Schema(description = "[모바일 앱 방식] 소셜 플랫폼 SDK에서 직접 발급받은 액세스 토큰. " +
+            "React Native, Flutter 등 모바일 앱에서 네이버/카카오/구글 SDK로 받은 토큰을 전달합니다. " +
+            "code 또는 accessToken 중 하나는 필수입니다.",
+            example = "AAAANvMf...mobile_app_access_token")
     private String accessToken;
 
 

--- a/src/main/java/com/application/domain/member/service/MemberService.java
+++ b/src/main/java/com/application/domain/member/service/MemberService.java
@@ -6,10 +6,12 @@ import com.application.domain.member.dto.MemberUpdateDto;
 import com.application.domain.member.entity.Member;
 import com.application.domain.member.enums.Gender;
 import com.application.domain.member.repository.MemberRepository;
+import com.application.domain.monitoring.repository.MonitoringRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
@@ -27,6 +29,7 @@ import java.util.UUID;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final MonitoringRepository monitoringRepository;
 
     public void saveMember(Member member){
         memberRepository.save(member);
@@ -50,7 +53,9 @@ public class MemberService {
         memberRepository.save(member);
     }
 
+    @Transactional
     public void deleteMember(Long memberId){
+        monitoringRepository.deleteByMemberId(memberId);
         memberRepository.deleteById(memberId);
     }
 

--- a/src/main/java/com/application/domain/monitoring/repository/MonitoringRepository.java
+++ b/src/main/java/com/application/domain/monitoring/repository/MonitoringRepository.java
@@ -12,4 +12,6 @@ public interface MonitoringRepository extends JpaRepository<Monitoring, Long> {
     Optional<Monitoring> findByDeviceNumber(String deviceNumber);
 
     boolean existsByDeviceNumber(String deviceNumber);
+
+    void deleteByMemberId(Long memberId);
 }


### PR DESCRIPTION
  ## 📌 작업 개요
  - 회원 탈퇴(DELETE /api/v2/members/delete/member) 요청 시 monitoring 테이블의 외래 키 제약 조건으로 인해 발생하던 500 에러 해결
  - 회원 삭제 전 해당 회원과 연결된 monitoring 데이터를 먼저 삭제하도록 로직 수정
  - 데이터 정합성 보장을 위해 `@Transactional` 어노테이션 적용

 ## 이슈번호
#56 

  ## 🔧 변경 사항
  - `MonitoringRepository`에 `deleteByMemberId(Long memberId)` 메서드 추가
  - `MemberService`에 `MonitoringRepository` 의존성 주입
  - `MemberService.deleteMember()` 메서드 수정:
    - 회원 삭제 전 monitoring 데이터 선삭제
    - `@Transactional` 추가하여 트랜잭션 보장

  ## ✨ 기타 참고 사항
  - 트랜잭션 처리를 통해 monitoring 삭제와 회원 삭제가 원자적으로 수행됨
  - 중간에 오류 발생 시 모든 작업이 롤백되어 데이터 정합성 유지
  - 향후 다른 테이블에서도 회원을 참조하는 경우, 동일한 방식으로 처리 필요

  ## ✅ PR 체크 리스트
  - [x] PR 템플릿에 맞추어 작성했어요.
  - [x] PR에 적절한 라벨을 선택했어요.
  - [x] 이슈번호가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
  - [x] 변경 내용에 대한 테스트를 진행했어요.
  - [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
  - [x] 로컬 서버에서 정상 동작을 확인했어요.
  - [x] 불필요한 코드/주석 삭제했어요.
