### PR TITLE
[#61] feat: 온보딩 성별 및 연령대 정보 저장 기능 추가

### DIFF
--- a/src/main/java/com/application/domain/member/controller/MemberV2Controller.java
+++ b/src/main/java/com/application/domain/member/controller/MemberV2Controller.java
@@ -6,6 +6,7 @@ import com.application.common.exception.custom.CustomApiException;
 import com.application.common.response.ResponseDto;
 import com.application.domain.member.dto.MemberDto;
 import com.application.domain.member.dto.MemberUpdateDto;
+import com.application.domain.member.dto.OnboardingDto;
 import com.application.domain.member.entity.Member;
 
 import com.application.domain.member.service.MemberService;
@@ -86,5 +87,16 @@ public class MemberV2Controller implements MemberV2ControllerDocs {
         }catch(MalformedURLException e){
             throw new RuntimeException("no find file");
         }
+    }
+
+    @Override
+    @PostMapping("/onboarding")
+    public ResponseEntity<?> saveOnboarding(@AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+                                            @Valid @RequestBody OnboardingDto onboardingDto,
+                                            BindingResult bindingResult) {
+        Member member = memberService.getMemberByCredentialId(customOAuth2User.getCredentialId());
+        memberService.saveOnboardingInfo(member, onboardingDto);
+
+        return new ResponseEntity<>(new ResponseDto<>(Constant.SUCCESS_CODE, "Save Onboarding Info", onboardingDto), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/application/domain/member/controller/MemberV2ControllerDocs.java
+++ b/src/main/java/com/application/domain/member/controller/MemberV2ControllerDocs.java
@@ -3,6 +3,7 @@ package com.application.domain.member.controller;
 import com.application.common.auth.dto.oauth2Dto.CustomOAuth2User;
 import com.application.common.response.ResponseDto;
 import com.application.domain.member.dto.MemberUpdateDto;
+import com.application.domain.member.dto.OnboardingDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -192,4 +193,41 @@ public interface MemberV2ControllerDocs {
 
     })
     ResponseEntity<Resource> getProfile(@AuthenticationPrincipal CustomOAuth2User customOAuth2User);
+
+    // 온보딩 정보 저장
+    @Operation(summary = "온보딩 정보 저장", description = "온보딩 화면에서 사용자의 성별과 연령대 정보를 저장")
+    @ApiResponses(value = {
+
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "저장 성공",
+                    content = @Content(schema = @Schema(example = """
+                            {
+                                "code": 1,
+                                "msg": "Save Onboarding Info",
+                                "data": {
+                                    "gender": "male",
+                                    "ageRange": "20_24"
+                                }
+                            }
+            """))),
+
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청",
+                    content = @Content(schema = @Schema(example = """
+                            {
+                                "code": -1,
+                                "msg": "유효성 검사 실패",
+                                "data": {
+                                    "gender": "성별 정보는 필수입니다.",
+                                    "ageRange": "연령대 정보는 필수입니다."
+                                }
+                            }
+            """)))
+
+    })
+    ResponseEntity<?> saveOnboarding(@AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+                                      @Valid @RequestBody OnboardingDto onboardingDto,
+                                      BindingResult bindingResult);
 }

--- a/src/main/java/com/application/domain/member/dto/OnboardingDto.java
+++ b/src/main/java/com/application/domain/member/dto/OnboardingDto.java
@@ -1,0 +1,18 @@
+package com.application.domain.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class OnboardingDto {
+
+    @NotBlank(message = "성별 정보는 필수입니다.")
+    private String gender; // "male", "female", "none"
+
+    @NotBlank(message = "연령대 정보는 필수입니다.")
+    private String ageRange; // "under_19", "20_24", "25_29", "30_34", "35_39", "50_over"
+}

--- a/src/main/java/com/application/domain/member/dto/OnboardingDto.java
+++ b/src/main/java/com/application/domain/member/dto/OnboardingDto.java
@@ -1,5 +1,6 @@
 package com.application.domain.member.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,11 +9,32 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@Schema(description = "온보딩 정보 요청 DTO")
 public class OnboardingDto {
 
+    @Schema(
+            description = "성별 정보",
+            example = "male",
+            allowableValues = {"male", "female", "none"},
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     @NotBlank(message = "성별 정보는 필수입니다.")
-    private String gender; // "male", "female", "none"
+    private String gender;
 
+    @Schema(
+            description = """
+                    연령대 정보
+                    - under_19: 19세 이하
+                    - 20_24: 20-24세
+                    - 25_29: 25-29세
+                    - 30_34: 30-34세
+                    - 35_39: 35-39세
+                    - 50_over: 50세 이상
+                    """,
+            example = "20_24",
+            allowableValues = {"under_19", "20_24", "25_29", "30_34", "35_39", "50_over"},
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     @NotBlank(message = "연령대 정보는 필수입니다.")
-    private String ageRange; // "under_19", "20_24", "25_29", "30_34", "35_39", "50_over"
+    private String ageRange;
 }

--- a/src/main/java/com/application/domain/member/entity/Member.java
+++ b/src/main/java/com/application/domain/member/entity/Member.java
@@ -1,6 +1,7 @@
 package com.application.domain.member.entity;
 
 import com.application.common.time.BaseTimeEntity;
+import com.application.domain.member.enums.AgeRange;
 import com.application.domain.member.enums.Gender;
 import com.application.domain.member.enums.Role;
 import com.application.domain.member.enums.SocialLogin;
@@ -42,6 +43,9 @@ public class Member extends BaseTimeEntity {
 
     @Column(name="age")
     private Integer age;
+
+    @Column(name="age_range")
+    private AgeRange ageRange;
 
     @Column(name="profile")
     private String profile;

--- a/src/main/java/com/application/domain/member/enums/AgeRange.java
+++ b/src/main/java/com/application/domain/member/enums/AgeRange.java
@@ -1,0 +1,32 @@
+package com.application.domain.member.enums;
+
+import lombok.Getter;
+
+import java.util.Optional;
+
+@Getter
+public enum AgeRange {
+    UNDER_19("under_19", "19세 이하"),
+    TWENTY_TO_TWENTY_FOUR("20_24", "20-24세"),
+    TWENTY_FIVE_TO_TWENTY_NINE("25_29", "25-29세"),
+    THIRTY_TO_THIRTY_FOUR("30_34", "30-34세"),
+    THIRTY_FIVE_TO_THIRTY_NINE("35_39", "35-39세"),
+    OVER_FIFTY("50_over", "50세 이상");
+
+    private final String code;
+    private final String description;
+
+    AgeRange(String code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    public static Optional<AgeRange> fromString(String ageRange) {
+        for (AgeRange value : AgeRange.values()) {
+            if (value.getCode().equalsIgnoreCase(ageRange)) {
+                return Optional.of(value);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/application/domain/member/service/MemberService.java
+++ b/src/main/java/com/application/domain/member/service/MemberService.java
@@ -3,7 +3,9 @@ package com.application.domain.member.service;
 import com.application.common.Constant;
 import com.application.common.exception.custom.CustomApiException;
 import com.application.domain.member.dto.MemberUpdateDto;
+import com.application.domain.member.dto.OnboardingDto;
 import com.application.domain.member.entity.Member;
+import com.application.domain.member.enums.AgeRange;
 import com.application.domain.member.enums.Gender;
 import com.application.domain.member.repository.MemberRepository;
 import com.application.domain.monitoring.repository.MonitoringRepository;
@@ -133,6 +135,15 @@ public class MemberService {
         }else{
             log.info("no file exist");
         }
+    }
+
+    public void saveOnboardingInfo(Member member, OnboardingDto onboardingDto) {
+        member.setGender(Gender.fromString(onboardingDto.getGender())
+                .orElseThrow(() -> new CustomApiException("Invalid Gender Type")));
+        member.setAgeRange(AgeRange.fromString(onboardingDto.getAgeRange())
+                .orElseThrow(() -> new CustomApiException("Invalid Age Range Type")));
+
+        memberRepository.save(member);
     }
 
 }


### PR DESCRIPTION
## 📌 작업 개요
  - 온보딩 화면에서 사용자의 성별(male, female, none)과 연령대 정보를 저장하는 기능 구현
  - 연령대는 6개 구간으로 분류 (19세 이하, 20-24세, 25-29세, 30-34세, 35-39세, 50세 이상)
  - Swagger 문서화를 통한 API 명세 제공

## 이슈번호
#61 

## ✨ 기타 참고 사항
  ### 새로 추가된 파일
  - `AgeRange.java`: 연령대 enum 정의
  - `OnboardingDto.java`: 온보딩 요청 DTO (성별, 연령대)

  ### 수정된 파일
  - `Member.java`: ageRange 필드 추가
  - `MemberService.java`: saveOnboardingInfo() 메서드 추가
  - `MemberV2Controller.java`: POST /api/v2/members/onboarding 엔드포인트 추가
  - `MemberV2ControllerDocs.java`: Swagger 문서화 추가
 
## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 이슈번호가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.