### PR TITLE
[#66] feat: 칵테일 즐겨찾기 api 구현

### DIFF
--- a/src/main/java/com/application/common/config/OpenApiConfig.java
+++ b/src/main/java/com/application/common/config/OpenApiConfig.java
@@ -1,0 +1,25 @@
+package com.application.common.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(
+                title = "Cocktail API",
+                version = "v2",
+                description = "칵테일 정보 조회 및 관리 API"
+        )
+)
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT",
+        description = "JWT 토큰을 입력해주세요 (Bearer Prefix 제외)"
+)
+public class OpenApiConfig {
+}

--- a/src/main/java/com/application/domain/cocktail/controller/CocktailBookmarkController.java
+++ b/src/main/java/com/application/domain/cocktail/controller/CocktailBookmarkController.java
@@ -1,0 +1,80 @@
+package com.application.domain.cocktail.controller;
+
+import com.application.common.auth.dto.oauth2Dto.CustomOAuth2User;
+import com.application.common.response.ResponseDto;
+import com.application.domain.cocktail.dto.response.BookmarkToggleResponse;
+import com.application.domain.cocktail.dto.response.CocktailResponseDto;
+import com.application.domain.cocktail.service.CocktailBookmarkService;
+import com.application.domain.member.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v2/cocktails")
+@RequiredArgsConstructor
+@Tag(name = "칵테일 북마크 API", description = "칵테일 북마크 추가/삭제 및 목록 조회")
+public class CocktailBookmarkController {
+
+    private final CocktailBookmarkService bookmarkService;
+    private final MemberService memberService;
+
+    /**
+     * 북마크 토글 (추가/삭제)
+     * POST /api/v2/cocktails/{cocktailId}/bookmarks
+     */
+    @Operation(
+            summary = "칵테일 북마크 토글",
+            description = "칵테일을 북마크에 추가하거나 삭제합니다. " +
+                    "이미 북마크되어 있으면 삭제, 북마크되어 있지 않으면 추가합니다."
+    )
+    @PostMapping("/{cocktailId}/bookmarks")
+    public ResponseEntity<ResponseDto<BookmarkToggleResponse>> toggleBookmark(
+            @PathVariable Long cocktailId,
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User
+    ) {
+        // credentialId로 Member PK 조회
+        Long memberId = memberService.getMemberByCredentialId(customOAuth2User.getCredentialId()).getId();
+
+        boolean isBookmarked = bookmarkService.toggleBookmark(memberId, cocktailId);
+
+        BookmarkToggleResponse response = BookmarkToggleResponse.builder()
+                .cocktailId(cocktailId)
+                .isBookmarked(isBookmarked)
+                .build();
+
+        return new ResponseEntity<>(
+                ResponseDto.onSuccess("북마크 토글 성공", response),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * 내가 북마크한 칵테일 목록 조회
+     * GET /api/v2/cocktails/bookmarks
+     */
+    @Operation(
+            summary = "내가 북마크한 칵테일 목록 조회",
+            description = "로그인한 사용자가 북마크한 칵테일 목록을 최근 북마크 순서대로 조회합니다."
+    )
+    @GetMapping("/bookmarks")
+    public ResponseEntity<ResponseDto<List<CocktailResponseDto>>> getMyBookmarks(
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User
+    ) {
+        Long memberId = memberService.getMemberByCredentialId(customOAuth2User.getCredentialId()).getId();
+
+        List<CocktailResponseDto> bookmarkedCocktails =
+                bookmarkService.getMyBookmarkedCocktails(memberId);
+
+        return new ResponseEntity<>(
+                ResponseDto.onSuccess("북마크 목록 조회 성공", bookmarkedCocktails),
+                HttpStatus.OK
+        );
+    }
+}

--- a/src/main/java/com/application/domain/cocktail/controller/CocktailBookmarkController.java
+++ b/src/main/java/com/application/domain/cocktail/controller/CocktailBookmarkController.java
@@ -7,6 +7,7 @@ import com.application.domain.cocktail.dto.response.CocktailResponseDto;
 import com.application.domain.cocktail.service.CocktailBookmarkService;
 import com.application.domain.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -32,7 +33,8 @@ public class CocktailBookmarkController {
     @Operation(
             summary = "칵테일 북마크 토글",
             description = "칵테일을 북마크에 추가하거나 삭제합니다. " +
-                    "이미 북마크되어 있으면 삭제, 북마크되어 있지 않으면 추가합니다."
+                    "이미 북마크되어 있으면 삭제, 북마크되어 있지 않으면 추가합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
     )
     @PostMapping("/{cocktailId}/bookmarks")
     public ResponseEntity<ResponseDto<BookmarkToggleResponse>> toggleBookmark(
@@ -61,7 +63,8 @@ public class CocktailBookmarkController {
      */
     @Operation(
             summary = "내가 북마크한 칵테일 목록 조회",
-            description = "로그인한 사용자가 북마크한 칵테일 목록을 최근 북마크 순서대로 조회합니다."
+            description = "로그인한 사용자가 북마크한 칵테일 목록을 최근 북마크 순서대로 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
     )
     @GetMapping("/bookmarks")
     public ResponseEntity<ResponseDto<List<CocktailResponseDto>>> getMyBookmarks(

--- a/src/main/java/com/application/domain/cocktail/controller/CocktailBookmarkController.java
+++ b/src/main/java/com/application/domain/cocktail/controller/CocktailBookmarkController.java
@@ -20,20 +20,20 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v2/cocktails")
 @RequiredArgsConstructor
-@Tag(name = "칵테일 북마크 API", description = "칵테일 북마크 추가/삭제 및 목록 조회")
+@Tag(name = "칵테일 즐겨찾기 API", description = "칵테일 즐겨찾기 추가/삭제 및 목록 조회")
 public class CocktailBookmarkController {
 
     private final CocktailBookmarkService bookmarkService;
     private final MemberService memberService;
 
     /**
-     * 북마크 토글 (추가/삭제)
+     * 즐겨찾기 토글 (추가/삭제)
      * POST /api/v2/cocktails/{cocktailId}/bookmarks
      */
     @Operation(
-            summary = "칵테일 북마크 토글",
-            description = "칵테일을 북마크에 추가하거나 삭제합니다. " +
-                    "이미 북마크되어 있으면 삭제, 북마크되어 있지 않으면 추가합니다.",
+            summary = "칵테일 즐겨찾기 토글",
+            description = "칵테일을 즐겨찾기에 추가하거나 삭제합니다. " +
+                    "이미 즐겨찾기되어 있으면 삭제, 즐겨찾기되어 있지 않으면 추가합니다.",
             security = @SecurityRequirement(name = "bearerAuth")
     )
     @PostMapping("/{cocktailId}/bookmarks")
@@ -52,18 +52,18 @@ public class CocktailBookmarkController {
                 .build();
 
         return new ResponseEntity<>(
-                ResponseDto.onSuccess("북마크 토글 성공", response),
+                ResponseDto.onSuccess("즐겨찾기 토글 성공", response),
                 HttpStatus.OK
         );
     }
 
     /**
-     * 내가 북마크한 칵테일 목록 조회
+     * 내가 즐겨찾기한 칵테일 목록 조회
      * GET /api/v2/cocktails/bookmarks
      */
     @Operation(
-            summary = "내가 북마크한 칵테일 목록 조회",
-            description = "로그인한 사용자가 북마크한 칵테일 목록을 최근 북마크 순서대로 조회합니다.",
+            summary = "내가 즐겨찾기한 칵테일 목록 조회",
+            description = "로그인한 사용자가 즐겨찾기한 칵테일 목록을 최근 즐겨찾기 순서대로 조회합니다.",
             security = @SecurityRequirement(name = "bearerAuth")
     )
     @GetMapping("/bookmarks")
@@ -76,7 +76,7 @@ public class CocktailBookmarkController {
                 bookmarkService.getMyBookmarkedCocktails(memberId);
 
         return new ResponseEntity<>(
-                ResponseDto.onSuccess("북마크 목록 조회 성공", bookmarkedCocktails),
+                ResponseDto.onSuccess("즐겨찾기 목록 조회 성공", bookmarkedCocktails),
                 HttpStatus.OK
         );
     }

--- a/src/main/java/com/application/domain/cocktail/controller/CocktailV2Controller.java
+++ b/src/main/java/com/application/domain/cocktail/controller/CocktailV2Controller.java
@@ -1,20 +1,25 @@
 package com.application.domain.cocktail.controller;
 
+import com.application.common.auth.dto.oauth2Dto.CustomOAuth2User;
 import com.application.common.response.ResponseDto;
 import com.application.domain.cocktail.dto.CocktailDto;
 import com.application.domain.cocktail.dto.request.CocktailRecommendationDto;
 import com.application.domain.cocktail.dto.request.ReactionReq;
+import com.application.domain.cocktail.dto.response.CocktailDetailResponseDto;
 import com.application.domain.cocktail.dto.response.GuideListResponseDto;
 import com.application.domain.cocktail.dto.response.GuideResponseDto;
 import com.application.domain.cocktail.dto.response.ReactionRes;
 import com.application.domain.cocktail.dto.request.CocktailSearchConditionDto;
 import com.application.domain.cocktail.dto.response.CocktailResponseDto;
+import com.application.domain.cocktail.entity.Cocktail;
 import com.application.domain.cocktail.enums.AbvLevel;
 import com.application.domain.cocktail.enums.Season;
 import com.application.domain.cocktail.enums.TasteLevel;
 
+import com.application.domain.cocktail.service.CocktailBookmarkService;
 import com.application.domain.cocktail.service.CocktailService;
 import com.application.domain.member.entity.ParsedMember;
+import com.application.domain.member.service.MemberService;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -39,6 +44,8 @@ import java.util.List;
 @Tag(name = "칵테일 관련 API", description = "칵테일 정보 조회, 수정, 삭제 및 검색 등")
 public class CocktailV2Controller implements CocktailV2ControllerDocs{
     private final CocktailService cocktailService;
+    private final CocktailBookmarkService bookmarkService;
+    private final MemberService memberService;
 
     // v2 -----------------------
 
@@ -210,19 +217,34 @@ public class CocktailV2Controller implements CocktailV2ControllerDocs{
      *     칵테일 상세 조회
      * </pre>
      * @param cocktailId
+     * @param customOAuth2User 로그인 사용자 정보 (선택)
      * @return
      */
-    @Operation(summary = "칵테일 상세 조회", description = "칵테일 상세 정보를 조회합니다.")
+    @Operation(
+            summary = "칵테일 상세 조회",
+            description = "칵테일 상세 정보를 조회합니다. 로그인한 사용자는 북마크 여부를 함께 확인할 수 있습니다."
+    )
     @GetMapping("/detail")
-    public ResponseEntity<ResponseDto<CocktailResponseDto>> getCocktail(
+    public ResponseEntity<ResponseDto<CocktailDetailResponseDto>> getCocktail(
             @Parameter(example = "1")
-            @RequestParam Long cocktailId
+            @RequestParam Long cocktailId,
+            @AuthenticationPrincipal(errorOnInvalidType = false) CustomOAuth2User customOAuth2User
     ){
+        // 1. 칵테일 엔티티 조회
+        Cocktail cocktail = cocktailService.getCocktailV2Entity(cocktailId);
 
-        CocktailResponseDto cocktail = cocktailService.getCocktailV2(cocktailId);
+        // 2. 북마크 여부 확인 (로그인한 사용자만)
+        Boolean isBookmarked = null;
+        if (customOAuth2User != null) {
+            Long memberId = memberService.getMemberByCredentialId(customOAuth2User.getCredentialId()).getId();
+            isBookmarked = bookmarkService.isBookmarked(memberId, cocktailId);
+        }
+
+        // 3. DTO 변환 (북마크 여부 포함)
+        CocktailDetailResponseDto response = CocktailDetailResponseDto.from(cocktail, isBookmarked);
 
         return new ResponseEntity<>(
-                ResponseDto.onSuccess("칵테일 조회 성공 (v2)", cocktail),
+                ResponseDto.onSuccess("칵테일 조회 성공 (v2)", response),
                 HttpStatus.OK
         );
     }

--- a/src/main/java/com/application/domain/cocktail/dto/response/BookmarkToggleResponse.java
+++ b/src/main/java/com/application/domain/cocktail/dto/response/BookmarkToggleResponse.java
@@ -1,0 +1,21 @@
+package com.application.domain.cocktail.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "북마크 토글 결과 응답 DTO")
+public class BookmarkToggleResponse {
+
+    @Schema(description = "칵테일 ID", example = "1")
+    private Long cocktailId;
+
+    @Schema(description = "북마크 상태 (true: 북마크됨, false: 북마크 취소됨)", example = "true")
+    private boolean isBookmarked;
+}

--- a/src/main/java/com/application/domain/cocktail/dto/response/CocktailDetailResponseDto.java
+++ b/src/main/java/com/application/domain/cocktail/dto/response/CocktailDetailResponseDto.java
@@ -1,0 +1,77 @@
+package com.application.domain.cocktail.dto.response;
+
+import com.application.domain.cocktail.entity.Cocktail;
+import com.application.domain.cocktail.entity.CocktailFlavor;
+import com.application.domain.cocktail.entity.CocktailMood;
+import com.application.domain.cocktail.enums.AbvLevel;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * 로그인한 사용자의 칵테일 상세 조회 시 북마크 여부를 포함한 DTO
+ */
+@Schema(description = "칵테일 상세 정보 응답 DTO (북마크 여부 포함)")
+public record CocktailDetailResponseDto(
+        @Schema(description = "칵테일 ID", example = "10")
+        Long id,
+
+        @Schema(description = "칵테일 이름", example = "마티니")
+        String korName,
+
+        String engName,
+        AbvLevel abvBand,
+        Integer maxAlcohol,
+        Integer minAlcohol,
+        String originText,
+        String season,
+        List<String> ingredients,
+        String style,
+        String glassType,
+        String glassImageUrl,
+        String base,
+        String imageUrl,
+
+        @Schema(description = "맛 태그 목록", example = "[\"상큼한\", \"달콤한\"]")
+        List<String> flavors,
+
+        @Schema(description = "분위기 태그 목록", example = "[\"파티\", \"데이트\"]")
+        List<String> moods,
+
+        @Schema(description = "북마크 여부 (로그인 사용자만, 비로그인은 null)", example = "true")
+        Boolean isBookmarked
+) {
+    public static CocktailDetailResponseDto from(Cocktail cocktail, Boolean isBookmarked) {
+        String rawIngredientsText = cocktail.getIngredientsText();
+        List<String> ingredients = (rawIngredientsText != null && !rawIngredientsText.isEmpty())
+                ? Arrays.stream(rawIngredientsText.split(","))
+                .map(String::trim)
+                .toList()
+                : List.of();
+
+        return new CocktailDetailResponseDto(
+                cocktail.getId(),
+                cocktail.getKorName(),
+                cocktail.getEngName(),
+                cocktail.getAbvBand(),
+                cocktail.getMaxAlcohol(),
+                cocktail.getMinAlcohol(),
+                cocktail.getOriginText(),
+                cocktail.getSeason(),
+                ingredients,
+                cocktail.getStyle(),
+                cocktail.getGlassType(),
+                cocktail.getGlassImageUrl(),
+                cocktail.getBase(),
+                cocktail.getImageUrl(),
+                cocktail.getFlavors().stream()
+                        .map(CocktailFlavor::getFlavorName)
+                        .toList(),
+                cocktail.getMoods().stream()
+                        .map(CocktailMood::getMoodName)
+                        .toList(),
+                isBookmarked
+        );
+    }
+}

--- a/src/main/java/com/application/domain/cocktail/entity/CocktailBookmark.java
+++ b/src/main/java/com/application/domain/cocktail/entity/CocktailBookmark.java
@@ -1,0 +1,42 @@
+package com.application.domain.cocktail.entity;
+
+import com.application.common.time.BaseTimeEntity;
+import com.application.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+    name = "cocktail_bookmark",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_member_cocktail_bookmark",
+            columnNames = {"member_id", "cocktail_id"}
+        )
+    }
+)
+public class CocktailBookmark extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cocktail_id", nullable = false)
+    private Cocktail cocktail;
+
+    @Builder
+    public CocktailBookmark(Member member, Cocktail cocktail) {
+        this.member = member;
+        this.cocktail = cocktail;
+    }
+}

--- a/src/main/java/com/application/domain/cocktail/repository/CocktailBookmarkRepository.java
+++ b/src/main/java/com/application/domain/cocktail/repository/CocktailBookmarkRepository.java
@@ -1,0 +1,32 @@
+package com.application.domain.cocktail.repository;
+
+import com.application.domain.cocktail.entity.CocktailBookmark;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CocktailBookmarkRepository extends JpaRepository<CocktailBookmark, Long> {
+
+    /**
+     * 특정 유저가 특정 칵테일을 북마크했는지 조회
+     */
+    Optional<CocktailBookmark> findByMemberIdAndCocktailId(Long memberId, Long cocktailId);
+
+    /**
+     * 특정 유저가 북마크한 모든 칵테일 조회 (최근 북마크 순서대로)
+     * Cocktail 엔티티도 함께 fetch join으로 가져와 N+1 문제 방지
+     */
+    @Query("SELECT cb FROM CocktailBookmark cb " +
+           "JOIN FETCH cb.cocktail c " +
+           "WHERE cb.member.id = :memberId " +
+           "ORDER BY cb.createdAt DESC")
+    List<CocktailBookmark> findByMemberIdOrderByCreatedAtDesc(@Param("memberId") Long memberId);
+
+    /**
+     * 북마크 여부 확인 (성능 최적화를 위한 boolean 반환)
+     */
+    boolean existsByMemberIdAndCocktailId(Long memberId, Long cocktailId);
+}

--- a/src/main/java/com/application/domain/cocktail/service/CocktailBookmarkService.java
+++ b/src/main/java/com/application/domain/cocktail/service/CocktailBookmarkService.java
@@ -1,0 +1,89 @@
+package com.application.domain.cocktail.service;
+
+import com.application.domain.cocktail.dto.response.CocktailResponseDto;
+import com.application.domain.cocktail.entity.Cocktail;
+import com.application.domain.cocktail.entity.CocktailBookmark;
+import com.application.domain.cocktail.repository.CocktailBookmarkRepository;
+import com.application.domain.cocktail.repository.CocktailRepository;
+import com.application.domain.member.entity.Member;
+import com.application.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CocktailBookmarkService {
+
+    private final CocktailBookmarkRepository bookmarkRepository;
+    private final CocktailRepository cocktailRepository;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 북마크 토글 (추가/삭제)
+     * - 북마크가 없으면 추가
+     * - 북마크가 있으면 삭제
+     */
+    @Transactional
+    public boolean toggleBookmark(Long memberId, Long cocktailId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        Cocktail cocktail = cocktailRepository.findById(cocktailId)
+                .orElseThrow(() -> new IllegalArgumentException("Cocktail not found"));
+
+        Optional<CocktailBookmark> existingBookmark =
+                bookmarkRepository.findByMemberIdAndCocktailId(memberId, cocktailId);
+
+        if (existingBookmark.isEmpty()) {
+            // 북마크 추가
+            createBookmark(member, cocktail);
+            return true; // 북마크됨
+        } else {
+            // 북마크 삭제
+            removeBookmark(existingBookmark.get());
+            return false; // 북마크 취소됨
+        }
+    }
+
+    /**
+     * 내가 북마크한 칵테일 목록 조회
+     * 최근 북마크 순서대로 정렬
+     */
+    @Transactional(readOnly = true)
+    public List<CocktailResponseDto> getMyBookmarkedCocktails(Long memberId) {
+        List<CocktailBookmark> bookmarks =
+                bookmarkRepository.findByMemberIdOrderByCreatedAtDesc(memberId);
+
+        return bookmarks.stream()
+                .map(bookmark -> CocktailResponseDto.from(bookmark.getCocktail()))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 북마크 여부 확인
+     */
+    @Transactional(readOnly = true)
+    public boolean isBookmarked(Long memberId, Long cocktailId) {
+        return bookmarkRepository.existsByMemberIdAndCocktailId(memberId, cocktailId);
+    }
+
+    // ===== Private Helper Methods =====
+
+    private void createBookmark(Member member, Cocktail cocktail) {
+        CocktailBookmark bookmark = CocktailBookmark.builder()
+                .member(member)
+                .cocktail(cocktail)
+                .build();
+        bookmarkRepository.save(bookmark);
+    }
+
+    private void removeBookmark(CocktailBookmark bookmark) {
+        bookmarkRepository.delete(bookmark);
+    }
+}

--- a/src/main/java/com/application/domain/cocktail/service/CocktailService.java
+++ b/src/main/java/com/application/domain/cocktail/service/CocktailService.java
@@ -206,6 +206,25 @@ public class CocktailService {
         return CocktailResponseDto.from(cocktail);
     }
 
+    /**
+     * 칵테일 엔티티 조회 (내부용 - 컨트롤러에서 북마크 여부 확인 시 사용)
+     * getCocktailV2와 동일한 로직이지만 DTO 대신 엔티티를 반환
+     */
+    public Cocktail getCocktailV2Entity(Long cocktailId) {
+        // 랜덤 ID 생성 (1부터 105까지 포함)
+        final long MIN_ID = 1;
+        final long MAX_ID = 105;
+
+        // 랜덤 조회 api 호출 시 사용됨
+        if(cocktailId == null) {
+            cocktailId = ThreadLocalRandom.current().nextLong(MIN_ID, MAX_ID + 1);
+        }
+
+        return cocktailRepository.findById(cocktailId).orElseThrow(
+                () -> new CustomApiException("칵테일이 존재하지 않습니다.")
+        );
+    }
+
     public CocktailResponseDto getRecommendation(CocktailRecommendationDto dto) {
 
         // 1. 조건에 맞는 모든 후보 칵테일 조회


### PR DESCRIPTION
 ## 📌 작업 개요
  - 로그인한 사용자가 칵테일을 즐겨찾기(북마크)할 수 있는 기능 구현
  - 북마크 토글 방식: 한 번 클릭하면 추가, 다시 클릭하면 삭제
  - 칵테일 상세 조회 시 북마크 여부 포함 (로그인 사용자만, 비로그인은 null)
  - 내가 북마크한 칵테일 목록 조회 기능 (최근 북마크 순서대로 정렬)

## 이슈번호
- #66 

  ## 🔧 주요 변경 사항

  ### 1. 신규 파일 생성 (6개)
  - `CocktailBookmark.java` - 북마크 엔티티 (BaseTimeEntity 상속, UNIQUE 제약)
  - `CocktailBookmarkRepository.java` - 북마크 Repository (FETCH JOIN으로 N+1 방지)
  - `CocktailBookmarkService.java` - 북마크 비즈니스 로직
  - `CocktailBookmarkController.java` - 북마크 API 엔드포인트
  - `BookmarkToggleResponse.java` - 북마크 토글 응답 DTO
  - `CocktailDetailResponseDto.java` - 북마크 여부 포함한 칵테일 상세 DTO (Record 타입)

  ### 2. 기존 파일 수정 (2개)
  - `CocktailService.java` - `getCocktailV2Entity()` 메서드 추가 (엔티티 반환)
  - `CocktailV2Controller.java` - 상세 조회 API 수정 (북마크 여부 포함)

  ### 3. API 엔드포인트
  - **POST** `/api/v2/cocktails/{cocktailId}/bookmarks` - 북마크 토글 (로그인 필수)
  - **GET** `/api/v2/cocktails/bookmarks` - 내 북마크 목록 조회 (로그인 필수)
  - **GET** `/api/v2/cocktails/detail` - 칵테일 상세 조회 (비로그인 가능, 로그인 시 북마크 여부 포함)

  ## 🎯 주요 구현 특징
  - **토글 방식**: CocktailReaction 패턴 참고하여 일관성 유지
  - **BaseTimeEntity**: createdAt으로 북마크 순서 자동 관리
  - **UNIQUE 제약조건**: DB 레벨에서 중복 북마크 방지 (member_id, cocktail_id)
  - **N+1 문제 방지**: FETCH JOIN 적용
  - **선택적 인증**: 상세 조회는 비로그인도 가능, 북마크 정보는 로그인 시만 포함
  - **CustomOAuth2User**: JWTFilter에서 SecurityContext에 저장된 인증 객체 사용

## ✨ 기타 참고 사항
- 기존 `CocktailResponseDto`를 수정하지 않고 새로운 `CocktailDetailResponseDto`를 생성하여 기존 목록 API에 영향 없음
- 북마크 여부 확인은 `existsByMemberIdAndCocktailId`로 성능 최적화
- 북마크 목록 조회 시 FETCH JOIN으로 칵테일 정보를 한 번에 가져와 쿼리 최적화

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 이슈번호가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요. (컴파일 확인 완료)
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요. (수정 안 함)
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.
