### PR TITLE
[#36] feat: 회원 다중 기기 지원 및 통합 모니터링 count 관리 기능 구현

### DIFF
--- a/src/main/java/com/application/common/auth/OAuth2Service.java
+++ b/src/main/java/com/application/common/auth/OAuth2Service.java
@@ -45,7 +45,7 @@ public class OAuth2Service {
         }
 
         ParsedMember parsedMember = strategy.parse(userInfo);
-        return handleMemberLoginFlow(parsedMember);
+        return handleMemberLoginFlow(parsedMember, reqSocialLoginDto.getDeviceNumber());
     }
 
     /**
@@ -128,13 +128,17 @@ public class OAuth2Service {
     /**
      * 로그인을 시도한 회원이 기존 회원인지 확인
      */
-    private ResSocialLoginDto handleMemberLoginFlow(ParsedMember parsedMember) {
+    private ResSocialLoginDto handleMemberLoginFlow(ParsedMember parsedMember, String deviceNumber) {
         Member member = memberService.getMemberByCredentialId(parsedMember.getCredentialId());
         if(member == null){
             // [신규 회원] DB에 없으면 -> '회원가입 대기 상태'
             return createCode(parsedMember);
         }else{
-            // [기존 회원] DB에 있으면 -> 바로 로그인 성공 (JWT 토큰 발급)
+            // [기존 회원] DB에 있으면 -> 기기-회원 매핑 후 로그인 성공 (JWT 토큰 발급)
+            if (deviceNumber != null && !deviceNumber.isBlank()) {
+                monitoringService.mapToMember(deviceNumber, member);
+                log.info("[LOGIN] Device {} mapped to member {}", deviceNumber, member.getId());
+            }
             return createJWTToken(member);
         }
     }

--- a/src/main/java/com/application/common/auth/dto/login/ReqSocialLoginDto.java
+++ b/src/main/java/com/application/common/auth/dto/login/ReqSocialLoginDto.java
@@ -35,9 +35,14 @@ public class ReqSocialLoginDto {
             example = "AAAANvMf...mobile_app_access_token")
     private String accessToken;
 
+    @JsonProperty("deviceNumber")
+    @Schema(description = "사용자 기기 고유 번호 (로그인 시 기기-회원 매핑에 사용)",
+            example = "device_unique_identifier_12345")
+    private String deviceNumber;
+
 
     @Override
     public String toString(){
-        return "[DTO] Provider : " + provider +"\n[DTO] code : " + code + "\n[DTO] state : " + state +"\n[DTO] accessToken : " + accessToken;
+        return "[DTO] Provider : " + provider +"\n[DTO] code : " + code + "\n[DTO] state : " + state +"\n[DTO] accessToken : " + accessToken + "\n[DTO] deviceNumber : " + deviceNumber;
     }
 }

--- a/src/main/java/com/application/domain/cocktail/controller/CocktailV2Controller.java
+++ b/src/main/java/com/application/domain/cocktail/controller/CocktailV2Controller.java
@@ -18,6 +18,7 @@ import com.application.domain.member.entity.ParsedMember;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -57,6 +58,7 @@ public class CocktailV2Controller implements CocktailV2ControllerDocs{
             summary = "칵테일 목록 조회",
             description =
                     "**[칵테일 목록 조회 및 필터링]**\n\n" + // \n\n 으로 단락 구분
+                            "🔓 **인증 불필요** - 이 API는 JWT 토큰 없이 사용 가능합니다.\n\n" +
                             "이 API는 다양한 검색 조건과 페이징을 지원합니다.<br/>" +
                             "모든 옵션은 nullable이며, 결과는 Page<CocktailResponseDto> 형태로 반환됩니다.\n\n" +
                             "**필터링 옵션:**\n" +
@@ -75,6 +77,7 @@ public class CocktailV2Controller implements CocktailV2ControllerDocs{
                             "- sort는 \"기준,오름/내림차순\" 형식으로 지정 가능합니다. (기본값 - id,asc)\n" +
                             "  - 기준 - [id | korName | engName] , 오름/내림차순 - [asc | desc]"
     )
+    @SecurityRequirements // 인증 불필요 명시
     @RequestMapping(path = "", method = RequestMethod.POST)
     public ResponseEntity<ResponseDto<Page<CocktailResponseDto>>> getCocktails(
             @Parameter(description = "검색 및 필터링 정보 (korName=아&abvBand=WEAK)")
@@ -104,7 +107,8 @@ public class CocktailV2Controller implements CocktailV2ControllerDocs{
      * </pre>
      * @return
      */
-    @Operation(summary = "칵테일 Best 10 조회", description = "추천을 많이 받은 칵테일의 정보를 조회합니다.")
+    @Operation(summary = "칵테일 Best 10 조회", description = "🔓 **인증 불필요** - 추천을 많이 받은 칵테일의 정보를 조회합니다.")
+    @SecurityRequirements
     @GetMapping("/best")
     public ResponseEntity<ResponseDto<List<CocktailResponseDto>>> getBestCocktails(
     ){
@@ -123,7 +127,8 @@ public class CocktailV2Controller implements CocktailV2ControllerDocs{
      * </pre>
      * @return
      */
-    @Operation(summary = "칵테일 최신순 top 10 조회", description = "최근 업데이트된 칵테일의 정보를 조회합니다.")
+    @Operation(summary = "칵테일 최신순 top 10 조회", description = "🔓 **인증 불필요** - 최근 업데이트된 칵테일의 정보를 조회합니다.")
+    @SecurityRequirements
     @GetMapping("/recent")
     public ResponseEntity<ResponseDto<List<CocktailResponseDto>>> getRecentCocktails(
     ){
@@ -143,7 +148,8 @@ public class CocktailV2Controller implements CocktailV2ControllerDocs{
      *
      * @return
      */
-    @Operation(summary = "상큼한 칵테일 7종 목록 조회", description = "칵테일 목록을 조회합니다.")
+    @Operation(summary = "상큼한 칵테일 7종 목록 조회", description = "🔓 **인증 불필요** - 칵테일 목록을 조회합니다.")
+    @SecurityRequirements
     @RequestMapping(path = "/refresh", method = RequestMethod.GET)
     public ResponseEntity<ResponseDto<List<CocktailResponseDto>>> getRefreshCocktails() {
 
@@ -166,7 +172,8 @@ public class CocktailV2Controller implements CocktailV2ControllerDocs{
      *
      * @return
      */
-    @Operation(summary = "입문자용 칵테일 7종 목록 조회", description = "칵테일 목록을 조회합니다.")
+    @Operation(summary = "입문자용 칵테일 7종 목록 조회", description = "🔓 **인증 불필요** - 칵테일 목록을 조회합니다.")
+    @SecurityRequirements
     @RequestMapping(path = "/beginner", method = RequestMethod.GET)
     public ResponseEntity<ResponseDto<List<CocktailResponseDto>>> getBeginnerCocktails() {
 
@@ -189,7 +196,8 @@ public class CocktailV2Controller implements CocktailV2ControllerDocs{
      *
      * @return
      */
-    @Operation(summary = "중급자 이상 칵테일 7종 목록 조회", description = "칵테일 목록을 조회합니다.")
+    @Operation(summary = "중급자 이상 칵테일 7종 목록 조회", description = "🔓 **인증 불필요** - 칵테일 목록을 조회합니다.")
+    @SecurityRequirements
     @RequestMapping(path = "/intermediate", method = RequestMethod.GET)
     public ResponseEntity<ResponseDto<List<CocktailResponseDto>>> getIntermediateCocktails() {
 
@@ -212,7 +220,8 @@ public class CocktailV2Controller implements CocktailV2ControllerDocs{
      * @param cocktailId
      * @return
      */
-    @Operation(summary = "칵테일 상세 조회", description = "칵테일 상세 정보를 조회합니다.")
+    @Operation(summary = "칵테일 상세 조회", description = "🔓 **인증 불필요** - 칵테일 상세 정보를 조회합니다.")
+    @SecurityRequirements
     @GetMapping("/detail")
     public ResponseEntity<ResponseDto<CocktailResponseDto>> getCocktail(
             @Parameter(example = "1")
@@ -233,7 +242,8 @@ public class CocktailV2Controller implements CocktailV2ControllerDocs{
      * </pre>
      * @return
      */
-    @Operation(summary = "칵테일 랜덤 조회", description = "ID 1부터 105 사이에서 무작위 칵테일 1개의 상세 정보를 조회합니다.")
+    @Operation(summary = "칵테일 랜덤 조회", description = "🔓 **인증 불필요** - ID 1부터 105 사이에서 무작위 칵테일 1개의 상세 정보를 조회합니다.")
+    @SecurityRequirements
     @GetMapping("/random")
     public ResponseEntity<ResponseDto<CocktailResponseDto>> getCocktailRandom(
     ){
@@ -252,7 +262,8 @@ public class CocktailV2Controller implements CocktailV2ControllerDocs{
      * </pre>
      * @return
      */
-    @Operation(summary = "칵테일 맞춤추천", description = "조건에 부합하는 칵테일을 조회합니다.")
+    @Operation(summary = "칵테일 맞춤추천", description = "🔓 **인증 불필요** - 조건에 부합하는 칵테일을 조회합니다.")
+    @SecurityRequirements
     @GetMapping("/recommendation")
     public ResponseEntity<ResponseDto<CocktailResponseDto>> getRecommendation(
             @Parameter(description = "질문에 대한 응답")
@@ -267,7 +278,8 @@ public class CocktailV2Controller implements CocktailV2ControllerDocs{
         );
     }
 
-    @Operation(summary = "칵테일 연관검색어 v2", description = "searchText에 따라 칵테일 이름을 조회합니다.")
+    @Operation(summary = "칵테일 연관검색어 v2", description = "🔓 **인증 불필요** - searchText에 따라 칵테일 이름을 조회합니다.")
+    @SecurityRequirements
     @GetMapping("/suggestions")
     public ResponseEntity<ResponseDto<List<String>>> getCocktailSuggestions(
             @Parameter(example = "아")
@@ -288,7 +300,8 @@ public class CocktailV2Controller implements CocktailV2ControllerDocs{
      * </pre>
      * @return
      */
-    @Operation(summary = "모든 칵테일 이름 조회", description = "DB에 저장된 모든 칵테일의 한글 이름과 영어 이름을 순번과 함께 순서대로 조회. 형식: [{id: 1, name: \"한글1\"}, {id: 2, name: \"영어1\"}, ...]")
+    @Operation(summary = "모든 칵테일 이름 조회", description = "🔓 **인증 불필요** - DB에 저장된 모든 칵테일의 한글 이름과 영어 이름을 순번과 함께 순서대로 조회. 형식: [{id: 1, name: \"한글1\"}, {id: 2, name: \"영어1\"}, ...]")
+    @SecurityRequirements
     @GetMapping("/names")
     public ResponseEntity<ResponseDto<List<CocktailNameDto>>> getAllCocktailNames(){
 
@@ -316,7 +329,8 @@ public class CocktailV2Controller implements CocktailV2ControllerDocs{
      * [가이드 목록 조회]
      * GET /api/v2/guide/list
      */
-    @Operation(summary = "칵테일 가이드 목록 조회", description = "모든 가이드의 파트 번호와 제목 리스트를 조회합니다.")
+    @Operation(summary = "칵테일 가이드 목록 조회", description = "🔓 **인증 불필요** - 모든 가이드의 파트 번호와 제목 리스트를 조회합니다.")
+    @SecurityRequirements
     @GetMapping("/guide/list")
     public ResponseEntity<ResponseDto<List<GuideListResponseDto>>> getGuideList() {
         List<GuideListResponseDto> list = cocktailService.getCocktailGuideList();
@@ -334,8 +348,9 @@ public class CocktailV2Controller implements CocktailV2ControllerDocs{
      * @return
      */
     @Operation(summary = "칵테일 가이드 상세 조회",
-            description = "각 가이드의 상세 정보를 조회합니다.\n\n" +
+            description = "🔓 **인증 불필요** - 각 가이드의 상세 정보를 조회합니다.\n\n" +
                     "part * 100 + ep 값을 전달하면 됩니다. (ex : part1 ep2 -> 102 ")
+    @SecurityRequirements
     @GetMapping("/guide")
     public ResponseEntity<ResponseDto<GuideResponseDto>> getCocktailGuide(
             @RequestParam Integer part
@@ -442,6 +457,7 @@ public class CocktailV2Controller implements CocktailV2ControllerDocs{
 //    }
 
     @Override
+    @Operation(summary = "칵테일 반응 조회", description = "🔒 **인증 필요** - 로그인한 사용자의 해당 칵테일에 대한 반응(좋아요/싫어요) 상태를 조회합니다.")
     @GetMapping("/{cocktailId}/reactions")
     public ResponseEntity<ReactionRes> getMyReaction( // todo ReactionDto.Response 뭐임?
                                                       @PathVariable Long cocktailId,
@@ -453,7 +469,8 @@ public class CocktailV2Controller implements CocktailV2ControllerDocs{
         return ResponseEntity.ok(response);
     }
 
-    @Override // todo swagger
+    @Override
+    @Operation(summary = "칵테일 반응 토글", description = "🔒 **인증 필요** - 로그인한 사용자의 칵테일 반응(좋아요/싫어요)을 추가/변경/삭제합니다.")
     @PostMapping("/{cocktailId}/reactions")
     public ResponseEntity<ReactionRes> toggleReaction(
             @PathVariable Long cocktailId,

--- a/src/main/java/com/application/domain/member/entity/Member.java
+++ b/src/main/java/com/application/domain/member/entity/Member.java
@@ -5,8 +5,12 @@ import com.application.domain.member.enums.AgeRange;
 import com.application.domain.member.enums.Gender;
 import com.application.domain.member.enums.Role;
 import com.application.domain.member.enums.SocialLogin;
+import com.application.domain.monitoring.entity.Monitoring;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
@@ -67,6 +71,9 @@ public class Member extends BaseTimeEntity {
 
     @Column(name="ad_term")
     private Boolean adTerm;
+
+    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
+    private List<Monitoring> monitorings = new ArrayList<>();
 
     @Builder
     public Member(String credentialId, String name, String nickname, String email, SocialLogin socialLogin, String profile, Role role

--- a/src/main/java/com/application/domain/monitoring/controller/MonitoringController.java
+++ b/src/main/java/com/application/domain/monitoring/controller/MonitoringController.java
@@ -1,9 +1,11 @@
 package com.application.domain.monitoring.controller;
 
 import com.application.domain.monitoring.dto.ReqTrackingDto;
+import com.application.domain.monitoring.dto.ResMonitoringInfoDto;
 import com.application.domain.monitoring.dto.ResTrackingDto;
 import com.application.domain.monitoring.service.MonitoringService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +29,20 @@ public class MonitoringController {
     @PostMapping("/track")
     public ResponseEntity<ResTrackingDto> trackPageAccess(@Valid @RequestBody ReqTrackingDto reqTrackingDto) {
         ResTrackingDto response = monitoringService.trackPageAccess(reqTrackingDto);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(
+            summary = "기기 정보 조회",
+            description = "기기 고유 번호로 기기 정보, 연령, 성별을 조회합니다. " +
+                    "회원인 경우 회원 정보(나이, 연령대, 성별)와 전체 기기의 count 합산을 반환하고, " +
+                    "비회원인 경우 기기 정보와 해당 기기의 count만 반환합니다."
+    )
+    @GetMapping("/info")
+    public ResponseEntity<ResMonitoringInfoDto> getMonitoringInfo(
+            @Parameter(description = "기기 고유 번호", required = true, example = "device_unique_identifier_12345")
+            @RequestParam String deviceNumber) {
+        ResMonitoringInfoDto response = monitoringService.getMonitoringInfo(deviceNumber);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/application/domain/monitoring/dto/ResMonitoringInfoDto.java
+++ b/src/main/java/com/application/domain/monitoring/dto/ResMonitoringInfoDto.java
@@ -1,0 +1,53 @@
+package com.application.domain.monitoring.dto;
+
+import com.application.domain.member.enums.AgeRange;
+import com.application.domain.member.enums.Gender;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "모니터링 정보 조회 응답 DTO")
+public class ResMonitoringInfoDto {
+
+    @JsonProperty("deviceNumber")
+    @Schema(description = "기기 고유 번호", example = "device_unique_identifier_12345")
+    private String deviceNumber;
+
+    @JsonProperty("isMember")
+    @Schema(description = "회원 여부", example = "true")
+    private Boolean isMember;
+
+    @JsonProperty("memberId")
+    @Schema(description = "회원 ID (회원인 경우에만)", example = "123")
+    private Long memberId;
+
+    @JsonProperty("age")
+    @Schema(description = "나이 (회원인 경우에만)", example = "25")
+    private Integer age;
+
+    @JsonProperty("ageRange")
+    @Schema(description = "연령대 (회원인 경우에만)", example = "TWENTIES")
+    private AgeRange ageRange;
+
+    @JsonProperty("gender")
+    @Schema(description = "성별 (회원인 경우에만)", example = "MALE")
+    private Gender gender;
+
+    @JsonProperty("totalCount")
+    @Schema(description = "전체 접근 횟수 (회원: 모든 기기 합산, 비회원: 기기별)", example = "50")
+    private Long totalCount;
+
+    @Builder
+    public ResMonitoringInfoDto(String deviceNumber, Boolean isMember, Long memberId,
+                                 Integer age, AgeRange ageRange, Gender gender, Long totalCount) {
+        this.deviceNumber = deviceNumber;
+        this.isMember = isMember;
+        this.memberId = memberId;
+        this.age = age;
+        this.ageRange = ageRange;
+        this.gender = gender;
+        this.totalCount = totalCount;
+    }
+}

--- a/src/main/java/com/application/domain/monitoring/dto/ResTrackingDto.java
+++ b/src/main/java/com/application/domain/monitoring/dto/ResTrackingDto.java
@@ -16,7 +16,7 @@ public class ResTrackingDto {
     private String deviceNumber;
 
     @JsonProperty("count")
-    @Schema(description = "현재 접근 횟수", example = "1")
+    @Schema(description = "현재 접근 횟수 (비회원: 기기별 count, 회원: 전체 count)", example = "1")
     private Long count;
 
     @JsonProperty("isFirstAccess")
@@ -27,11 +27,21 @@ public class ResTrackingDto {
     @Schema(description = "최초 접근 시간 (DB 레코드 생성 시간)", example = "2024-01-15T10:30:00")
     private LocalDateTime createdAt;
 
+    @JsonProperty("isMember")
+    @Schema(description = "회원 여부 (true: 회원, false: 비회원)", example = "false")
+    private Boolean isMember;
+
+    @JsonProperty("memberId")
+    @Schema(description = "회원 ID (회원인 경우에만 존재)", example = "123")
+    private Long memberId;
+
     @Builder
-    public ResTrackingDto(String deviceNumber, Long count, Boolean isFirstAccess, LocalDateTime createdAt) {
+    public ResTrackingDto(String deviceNumber, Long count, Boolean isFirstAccess, LocalDateTime createdAt, Boolean isMember, Long memberId) {
         this.deviceNumber = deviceNumber;
         this.count = count;
         this.isFirstAccess = isFirstAccess;
         this.createdAt = createdAt;
+        this.isMember = isMember;
+        this.memberId = memberId;
     }
 }

--- a/src/main/java/com/application/domain/monitoring/repository/MonitoringRepository.java
+++ b/src/main/java/com/application/domain/monitoring/repository/MonitoringRepository.java
@@ -2,8 +2,11 @@ package com.application.domain.monitoring.repository;
 
 import com.application.domain.monitoring.entity.Monitoring;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -14,4 +17,9 @@ public interface MonitoringRepository extends JpaRepository<Monitoring, Long> {
     boolean existsByDeviceNumber(String deviceNumber);
 
     void deleteByMemberId(Long memberId);
+
+    List<Monitoring> findAllByMemberId(Long memberId);
+
+    @Query("SELECT COALESCE(SUM(m.count), 0) FROM monitoring m WHERE m.member.id = :memberId")
+    Long sumCountByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/application/domain/monitoring/service/MonitoringService.java
+++ b/src/main/java/com/application/domain/monitoring/service/MonitoringService.java
@@ -1,7 +1,9 @@
 package com.application.domain.monitoring.service;
 
+import com.application.common.exception.custom.CustomApiException;
 import com.application.domain.member.entity.Member;
 import com.application.domain.monitoring.dto.ReqTrackingDto;
+import com.application.domain.monitoring.dto.ResMonitoringInfoDto;
 import com.application.domain.monitoring.dto.ResTrackingDto;
 import com.application.domain.monitoring.entity.Monitoring;
 import com.application.domain.monitoring.repository.MonitoringRepository;
@@ -156,5 +158,29 @@ public class MonitoringService {
             return 0L;
         }
         return monitoringRepository.sumCountByMemberId(memberId);
+    }
+
+    /**
+     * deviceNumber로 기기 정보, 연령, 성별 조회
+     * 회원이면 회원 정보 포함, 비회원이면 기기 정보만 반환
+     */
+    @Transactional(readOnly = true)
+    public ResMonitoringInfoDto getMonitoringInfo(String deviceNumber) {
+        Monitoring monitoring = monitoringRepository.findByDeviceNumber(deviceNumber)
+                .orElseThrow(() -> new CustomApiException("해당 기기 정보를 찾을 수 없습니다."));
+
+        Member member = monitoring.getMember();
+        boolean isMember = (member != null);
+        Long totalCount = isMember ? getTotalCountByMember(member) : monitoring.getCount();
+
+        return ResMonitoringInfoDto.builder()
+                .deviceNumber(deviceNumber)
+                .isMember(isMember)
+                .memberId(isMember ? member.getId() : null)
+                .age(isMember ? member.getAge() : null)
+                .ageRange(isMember ? member.getAgeRange() : null)
+                .gender(isMember ? member.getGender() : null)
+                .totalCount(totalCount)
+                .build();
     }
 }

--- a/src/main/java/com/application/domain/monitoring/service/MonitoringService.java
+++ b/src/main/java/com/application/domain/monitoring/service/MonitoringService.java
@@ -49,6 +49,7 @@ public class MonitoringService {
 
     /**
      * 페이지 접근 추적 (프론트에서 전달받은 count 값으로 업데이트)
+     * 회원이면 전체 count 합산 반환, 비회원이면 기기별 count 반환
      */
     @Transactional
     public ResTrackingDto trackPageAccess(ReqTrackingDto reqTrackingDto) {
@@ -63,13 +64,20 @@ public class MonitoringService {
             monitoring.updateCount(count);
             monitoringRepository.save(monitoring);
 
-            log.info("[MONITORING] Updated - Device: {}, Count: {}", deviceNumber, count);
+            Member member = monitoring.getMember();
+            boolean isMember = (member != null);
+            Long totalCount = isMember ? getTotalCountByMember(member) : monitoring.getCount();
+
+            log.info("[MONITORING] Updated - Device: {}, Count: {}, IsMember: {}, TotalCount: {}",
+                    deviceNumber, count, isMember, totalCount);
 
             return ResTrackingDto.builder()
                     .deviceNumber(deviceNumber)
-                    .count(monitoring.getCount())
+                    .count(totalCount)
                     .isFirstAccess(false)
                     .createdAt(monitoring.getCreatedAt())
+                    .isMember(isMember)
+                    .memberId(isMember ? member.getId() : null)
                     .build();
         } else {
             // 최초 접근: 새로운 레코드 생성
@@ -87,6 +95,8 @@ public class MonitoringService {
                     .count(savedMonitoring.getCount())
                     .isFirstAccess(true)
                     .createdAt(savedMonitoring.getCreatedAt())
+                    .isMember(false)
+                    .memberId(null)
                     .build();
         }
     }
@@ -124,5 +134,27 @@ public class MonitoringService {
     @Transactional(readOnly = true)
     public Optional<Monitoring> getByDeviceNumber(String deviceNumber) {
         return monitoringRepository.findByDeviceNumber(deviceNumber);
+    }
+
+    /**
+     * 회원의 모든 기기 count 합산 조회
+     */
+    @Transactional(readOnly = true)
+    public Long getTotalCountByMember(Member member) {
+        if (member == null) {
+            return 0L;
+        }
+        return monitoringRepository.sumCountByMemberId(member.getId());
+    }
+
+    /**
+     * 회원 ID로 모든 기기 count 합산 조회
+     */
+    @Transactional(readOnly = true)
+    public Long getTotalCountByMemberId(Long memberId) {
+        if (memberId == null) {
+            return 0L;
+        }
+        return monitoringRepository.sumCountByMemberId(memberId);
     }
 }


### PR DESCRIPTION
 ## 📌 작업 개요
- 회원의 다중 기기 지원 및 통합 모니터링 count 관리 기능 구현
- 이제 한 회원이 여러 기기(iPhone, iPad, Android 등)를 사용하더라도 모든 기기의 접근 횟수가 통합되어 관리됩니다.
- 기기 정보, 연령 성별 을 반환하는 api 구현 (/monitoring/info)

## 이슈 번호
- #36 

## 🔧 주요 변경 사항

### 1. 엔티티 및 Repository 개선
  - **Member 엔티티**: Monitoring과 양방향 관계 매핑 추가 (`@OneToMany`)
  - **MonitoringRepository**:
    - `findAllByMemberId()`: 회원의 모든 기기 조회
    - `sumCountByMemberId()`: 회원의 전체 count 합산 조회

### 2. 로그인 시 기기 자동 매핑
  - `ReqSocialLoginDto`에 `deviceNumber` 필드 추가
  - 로그인 성공 시 해당 기기를 회원에게 자동 매핑
  - **효과**: 회원이 새로운 기기로 로그인하면 자동으로 해당 기기도 회원과 연결됨

### 3. 모니터링 API 개선
  - **trackPageAccess API 응답 변경**:
    - **비회원**: 해당 기기의 count만 반환 (`isMember: false`)
    - **회원**: 모든 기기의 count 합산하여 반환 (`isMember: true`, `memberId` 포함)

  - **ResTrackingDto 필드 추가**:
    - `isMember`: 회원 여부
    - `memberId`: 회원 ID (회원인 경우에만)

### 4. MonitoringService 메서드 추가
  - `getTotalCountByMember(Member)`: 회원의 전체 count 조회
  - `getTotalCountByMemberId(Long)`: 회원 ID로 전체 count 조회

## 작동 시나리오

  ### 시나리오 1: 비로그인 → 회원가입 → 다중 기기 사용
  1. 비회원이 deviceA로 앱 사용 (count=10)
  → 응답: {count: 10, isMember: false}
  2. 회원가입 시 deviceA가 회원에게 매핑됨
  → 응답: {count: 10, isMember: true, memberId: 1}
  3. 회원이 deviceB로 로그인 (자동 매핑)
  → 응답: {count: 10, isMember: true}
  4. deviceB로 앱 사용 (count=5 추가)
  → 응답: {count: 15, isMember: true}  // 10 + 5 합산

  ### 시나리오 2: 한 회원이 여러 기기 동시 사용
  Member#1:
  - iPhone (deviceA): count=20
  - iPad (deviceB): count=5
  - Android (deviceC): count=3

  어느 기기에서든 trackPageAccess 호출 시:
  → 응답: {count: 28, isMember: true, memberId: 1}

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 이슈번호가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요. (컴파일 확인 완료)
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요. (수정 안 함)
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.
