### PR TITLE
[#61] feat: 기기 번호 기반 온보딩 시스템 구현

### DIFF
--- a/src/main/java/com/application/domain/member/controller/MemberV2ControllerDocs.java
+++ b/src/main/java/com/application/domain/member/controller/MemberV2ControllerDocs.java
@@ -195,7 +195,22 @@ public interface MemberV2ControllerDocs {
     ResponseEntity<Resource> getProfile(@AuthenticationPrincipal CustomOAuth2User customOAuth2User);
 
     // 온보딩 정보 저장
-    @Operation(summary = "온보딩 정보 저장", description = "온보딩 화면에서 사용자의 성별과 연령대 정보를 저장")
+    @Operation(
+            summary = "회원 온보딩 정보 저장",
+            description = """
+                    🔒 **인증 필요** - 로그인한 사용자의 온보딩 정보를 저장합니다.
+
+                    온보딩 화면에서 사용자의 성별과 연령대 정보를 Member 테이블에 저장하며,
+                    해당 회원이 사용하는 모든 기기의 온보딩 상태를 자동으로 동기화합니다.
+
+                    **비로그인 사용자는 `/api/v2/monitoring/onboarding` API를 사용해야 합니다.**
+
+                    **Request Body:**
+                    - gender (필수): 성별 정보
+                    - ageRange (필수): 연령대 정보
+                    - deviceNumber (선택): 사용하지 않음, 생략 가능
+                    """
+    )
     @ApiResponses(value = {
 
             @ApiResponse(

--- a/src/main/java/com/application/domain/member/dto/OnboardingDto.java
+++ b/src/main/java/com/application/domain/member/dto/OnboardingDto.java
@@ -13,7 +13,7 @@ import lombok.Setter;
 public class OnboardingDto {
 
     @Schema(
-            description = "기기 고유 번호 (회원 온보딩 시 필수)",
+            description = "기기 고유 번호 (현재 사용되지 않음, 생략 권장)",
             example = "device_unique_identifier_12345",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )

--- a/src/main/java/com/application/domain/member/service/MemberService.java
+++ b/src/main/java/com/application/domain/member/service/MemberService.java
@@ -137,6 +137,7 @@ public class MemberService {
         }
     }
 
+    @Transactional
     public void saveOnboardingInfo(Member member, OnboardingDto onboardingDto) {
         member.setGender(Gender.fromString(onboardingDto.getGender())
                 .orElseThrow(() -> new CustomApiException("Invalid Gender Type")));
@@ -144,6 +145,16 @@ public class MemberService {
                 .orElseThrow(() -> new CustomApiException("Invalid Age Range Type")));
 
         memberRepository.save(member);
+
+        // 해당 회원의 모든 기기의 온보딩 상태를 완료로 동기화
+        monitoringRepository.findAllByMemberId(member.getId()).forEach(monitoring -> {
+            monitoring.markOnboardingCompleted();
+            monitoringRepository.save(monitoring);
+        });
+
+        log.info("[ONBOARDING] Member onboarding saved - MemberId: {}, Gender: {}, AgeRange: {}, Devices synchronized: {}",
+                member.getId(), member.getGender(), member.getAgeRange(),
+                monitoringRepository.findAllByMemberId(member.getId()).size());
     }
 
 }

--- a/src/main/java/com/application/domain/monitoring/controller/MonitoringController.java
+++ b/src/main/java/com/application/domain/monitoring/controller/MonitoringController.java
@@ -1,7 +1,11 @@
 package com.application.domain.monitoring.controller;
 
+import com.application.common.Constant;
+import com.application.common.response.ResponseDto;
+import com.application.domain.monitoring.dto.ReqSaveOnboardingDto;
 import com.application.domain.monitoring.dto.ReqTrackingDto;
 import com.application.domain.monitoring.dto.ResMonitoringInfoDto;
+import com.application.domain.monitoring.dto.ResOnboardingStatusDto;
 import com.application.domain.monitoring.dto.ResTrackingDto;
 import com.application.domain.monitoring.service.MonitoringService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,6 +13,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -44,5 +49,32 @@ public class MonitoringController {
             @RequestParam String deviceNumber) {
         ResMonitoringInfoDto response = monitoringService.getMonitoringInfo(deviceNumber);
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(
+            summary = "온보딩 상태 확인",
+            description = "기기 고유 번호로 온보딩 완료 여부를 확인합니다. " +
+                    "회원인 경우 Member의 gender와 ageRange로 확인하고, " +
+                    "비회원인 경우 Monitoring의 onboardingCompleted로 확인합니다. " +
+                    "최초 접근 시 온보딩이 필요한 것으로 반환됩니다."
+    )
+    @GetMapping("/onboarding/status")
+    public ResponseEntity<ResOnboardingStatusDto> getOnboardingStatus(
+            @Parameter(description = "기기 고유 번호", required = true, example = "device_unique_identifier_12345")
+            @RequestParam String deviceNumber) {
+        ResOnboardingStatusDto response = monitoringService.getOnboardingStatus(deviceNumber);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(
+            summary = "비회원 온보딩 정보 저장",
+            description = "비회원(로그인 전) 사용자의 온보딩 정보를 Monitoring 테이블에 저장합니다. " +
+                    "나중에 로그인하면 이 정보가 Member로 복사됩니다. " +
+                    "이미 회원으로 등록된 기기는 회원 온보딩 API를 사용해야 합니다."
+    )
+    @PostMapping("/onboarding")
+    public ResponseEntity<?> saveNonMemberOnboarding(@Valid @RequestBody ReqSaveOnboardingDto dto) {
+        monitoringService.saveNonMemberOnboarding(dto);
+        return new ResponseEntity<>(new ResponseDto<>(Constant.SUCCESS_CODE, "Save Non-Member Onboarding Info", dto), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/application/domain/monitoring/controller/MonitoringController.java
+++ b/src/main/java/com/application/domain/monitoring/controller/MonitoringController.java
@@ -53,10 +53,21 @@ public class MonitoringController {
 
     @Operation(
             summary = "온보딩 상태 확인",
-            description = "기기 고유 번호로 온보딩 완료 여부를 확인합니다. " +
-                    "회원인 경우 Member의 gender와 ageRange로 확인하고, " +
-                    "비회원인 경우 Monitoring의 onboardingCompleted로 확인합니다. " +
-                    "최초 접근 시 온보딩이 필요한 것으로 반환됩니다."
+            description = """
+                    🔓 **인증 불필요** - 기기 고유 번호로 온보딩 완료 여부를 확인합니다.
+
+                    스플래시 화면에서 이 API를 호출하여 온보딩 화면 표시 여부를 결정합니다.
+
+                    **확인 로직:**
+                    - 회원(로그인): Member 테이블의 gender, ageRange 필드로 확인
+                    - 비회원(비로그인): Monitoring 테이블의 onboardingCompleted 필드로 확인
+                    - 최초 접근: requiresOnboarding=true 반환
+
+                    **Response:**
+                    - onboardingCompleted: 온보딩 완료 여부
+                    - requiresOnboarding: 온보딩이 필요한지 여부 (onboardingCompleted의 반대값)
+                    - isMember: 회원 여부
+                    """
     )
     @GetMapping("/onboarding/status")
     public ResponseEntity<ResOnboardingStatusDto> getOnboardingStatus(
@@ -68,9 +79,19 @@ public class MonitoringController {
 
     @Operation(
             summary = "비회원 온보딩 정보 저장",
-            description = "비회원(로그인 전) 사용자의 온보딩 정보를 Monitoring 테이블에 저장합니다. " +
-                    "나중에 로그인하면 이 정보가 Member로 복사됩니다. " +
-                    "이미 회원으로 등록된 기기는 회원 온보딩 API를 사용해야 합니다."
+            description = """
+                    🔓 **인증 불필요** - 비로그인 사용자의 온보딩 정보를 저장합니다.
+
+                    비회원(로그인 전) 사용자의 온보딩 정보를 Monitoring 테이블에 저장합니다.
+                    나중에 로그인하면 이 정보가 자동으로 Member 테이블로 복사됩니다.
+
+                    **로그인한 사용자는 `/api/v2/members/onboarding` API를 사용해야 합니다.**
+
+                    **Request Body:**
+                    - deviceNumber (필수): 기기 고유 번호
+                    - gender (필수): 성별 정보
+                    - ageRange (필수): 연령대 정보
+                    """
     )
     @PostMapping("/onboarding")
     public ResponseEntity<?> saveNonMemberOnboarding(@Valid @RequestBody ReqSaveOnboardingDto dto) {

--- a/src/main/java/com/application/domain/monitoring/dto/ReqSaveOnboardingDto.java
+++ b/src/main/java/com/application/domain/monitoring/dto/ReqSaveOnboardingDto.java
@@ -1,22 +1,17 @@
-package com.application.domain.member.dto;
+package com.application.domain.monitoring.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.Data;
 
-@Getter
-@Setter
-@NoArgsConstructor
-@Schema(description = "온보딩 정보 요청 DTO")
-public class OnboardingDto {
+@Data
+@Schema(description = "비회원 온보딩 정보 저장 요청 DTO")
+public class ReqSaveOnboardingDto {
 
-    @Schema(
-            description = "기기 고유 번호 (회원 온보딩 시 필수)",
-            example = "device_unique_identifier_12345",
-            requiredMode = Schema.RequiredMode.NOT_REQUIRED
-    )
+    @NotBlank(message = "기기 번호는 필수입니다.")
+    @JsonProperty("deviceNumber")
+    @Schema(description = "기기 고유 번호", example = "device_unique_identifier_12345", requiredMode = Schema.RequiredMode.REQUIRED)
     private String deviceNumber;
 
     @Schema(
@@ -26,6 +21,7 @@ public class OnboardingDto {
             requiredMode = Schema.RequiredMode.REQUIRED
     )
     @NotBlank(message = "성별 정보는 필수입니다.")
+    @JsonProperty("gender")
     private String gender;
 
     @Schema(
@@ -43,5 +39,6 @@ public class OnboardingDto {
             requiredMode = Schema.RequiredMode.REQUIRED
     )
     @NotBlank(message = "연령대 정보는 필수입니다.")
+    @JsonProperty("ageRange")
     private String ageRange;
 }

--- a/src/main/java/com/application/domain/monitoring/dto/ResOnboardingStatusDto.java
+++ b/src/main/java/com/application/domain/monitoring/dto/ResOnboardingStatusDto.java
@@ -1,0 +1,28 @@
+package com.application.domain.monitoring.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@Schema(description = "온보딩 상태 응답 DTO")
+public class ResOnboardingStatusDto {
+
+    @JsonProperty("onboardingCompleted")
+    @Schema(description = "온보딩 완료 여부", example = "true")
+    private Boolean onboardingCompleted;
+
+    @JsonProperty("requiresOnboarding")
+    @Schema(description = "온보딩이 필요한지 여부 (onboardingCompleted의 반대)", example = "false")
+    private Boolean requiresOnboarding;
+
+    @JsonProperty("isMember")
+    @Schema(description = "회원 여부", example = "true")
+    private Boolean isMember;
+
+    @JsonProperty("deviceNumber")
+    @Schema(description = "기기 고유 번호", example = "device_unique_identifier_12345")
+    private String deviceNumber;
+}

--- a/src/main/java/com/application/domain/monitoring/entity/Monitoring.java
+++ b/src/main/java/com/application/domain/monitoring/entity/Monitoring.java
@@ -2,6 +2,8 @@ package com.application.domain.monitoring.entity;
 
 import com.application.common.time.BaseTimeEntity;
 import com.application.domain.member.entity.Member;
+import com.application.domain.member.enums.AgeRange;
+import com.application.domain.member.enums.Gender;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -23,15 +25,27 @@ public class Monitoring extends BaseTimeEntity {
     @Column(name="count", nullable = false)
     private Long count = 0L;
 
+    @Column(name="onboarding_completed", nullable = false, columnDefinition = "boolean default false")
+    private Boolean onboardingCompleted = false;
+
+    @Column(name="gender")
+    private Gender gender;
+
+    @Column(name="age_range")
+    private AgeRange ageRange;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
     @Builder
-    public Monitoring(String deviceNumber, Long count, Member member) {
+    public Monitoring(String deviceNumber, Long count, Member member, Boolean onboardingCompleted, Gender gender, AgeRange ageRange) {
         this.deviceNumber = deviceNumber;
         this.count = count != null ? count : 0L;
         this.member = member;
+        this.onboardingCompleted = onboardingCompleted != null ? onboardingCompleted : false;
+        this.gender = gender;
+        this.ageRange = ageRange;
     }
 
     /**
@@ -55,5 +69,21 @@ public class Monitoring extends BaseTimeEntity {
      */
     public void mapToMember(Member member) {
         this.member = member;
+    }
+
+    /**
+     * 온보딩 정보 저장 (비회원용)
+     */
+    public void saveOnboardingInfo(Gender gender, AgeRange ageRange) {
+        this.gender = gender;
+        this.ageRange = ageRange;
+        this.onboardingCompleted = true;
+    }
+
+    /**
+     * 온보딩 완료 상태로 설정 (회원 로그인 시 동기화용)
+     */
+    public void markOnboardingCompleted() {
+        this.onboardingCompleted = true;
     }
 }

--- a/src/main/java/com/application/domain/monitoring/service/MonitoringService.java
+++ b/src/main/java/com/application/domain/monitoring/service/MonitoringService.java
@@ -2,8 +2,12 @@ package com.application.domain.monitoring.service;
 
 import com.application.common.exception.custom.CustomApiException;
 import com.application.domain.member.entity.Member;
+import com.application.domain.member.enums.AgeRange;
+import com.application.domain.member.enums.Gender;
+import com.application.domain.monitoring.dto.ReqSaveOnboardingDto;
 import com.application.domain.monitoring.dto.ReqTrackingDto;
 import com.application.domain.monitoring.dto.ResMonitoringInfoDto;
+import com.application.domain.monitoring.dto.ResOnboardingStatusDto;
 import com.application.domain.monitoring.dto.ResTrackingDto;
 import com.application.domain.monitoring.entity.Monitoring;
 import com.application.domain.monitoring.repository.MonitoringRepository;
@@ -104,7 +108,8 @@ public class MonitoringService {
     }
 
     /**
-     * 회원가입 시 모니터링 데이터와 회원 매핑
+     * 회원가입/로그인 시 모니터링 데이터와 회원 매핑
+     * 비회원 상태에서 온보딩을 완료한 경우, 온보딩 데이터를 Member로 복사
      */
     @Transactional
     public void mapToMember(String deviceNumber, Member member) {
@@ -116,6 +121,27 @@ public class MonitoringService {
         if (monitoringOpt.isPresent()) {
             Monitoring monitoring = monitoringOpt.get();
             monitoring.mapToMember(member);
+
+            // 비회원 온보딩 데이터가 있으면 Member로 복사
+            if (monitoring.getOnboardingCompleted() && monitoring.getGender() != null && monitoring.getAgeRange() != null) {
+                // Member에 온보딩 정보가 없을 때만 복사
+                if (member.getGender() == null || member.getAgeRange() == null) {
+                    member.setGender(monitoring.getGender());
+                    member.setAgeRange(monitoring.getAgeRange());
+                    log.info("[ONBOARDING] Merged non-member onboarding to member - Device: {}, MemberId: {}, Gender: {}, AgeRange: {}",
+                            deviceNumber, member.getId(), monitoring.getGender(), monitoring.getAgeRange());
+
+                    // 해당 회원의 모든 기기의 온보딩 상태를 완료로 동기화
+                    monitoringRepository.findAllByMemberId(member.getId()).forEach(m -> {
+                        m.markOnboardingCompleted();
+                        monitoringRepository.save(m);
+                    });
+                } else {
+                    // Member에 이미 온보딩 정보가 있으면, Monitoring의 온보딩 완료 상태만 동기화
+                    monitoring.markOnboardingCompleted();
+                }
+            }
+
             monitoringRepository.save(monitoring);
             log.info("[MONITORING] Mapped device {} to member {}", deviceNumber, member.getId());
         } else {
@@ -182,5 +208,85 @@ public class MonitoringService {
                 .gender(isMember ? member.getGender() : null)
                 .totalCount(totalCount)
                 .build();
+    }
+
+    /**
+     * deviceNumber로 온보딩 상태 확인
+     * 회원이면 Member의 온보딩 정보 확인, 비회원이면 Monitoring의 온보딩 정보 확인
+     */
+    @Transactional(readOnly = true)
+    public ResOnboardingStatusDto getOnboardingStatus(String deviceNumber) {
+        Optional<Monitoring> monitoringOpt = monitoringRepository.findByDeviceNumber(deviceNumber);
+
+        if (monitoringOpt.isEmpty()) {
+            // 최초 접근: 온보딩 필요
+            log.info("[ONBOARDING] First access for device: {}", deviceNumber);
+            return ResOnboardingStatusDto.builder()
+                    .deviceNumber(deviceNumber)
+                    .onboardingCompleted(false)
+                    .requiresOnboarding(true)
+                    .isMember(false)
+                    .build();
+        }
+
+        Monitoring monitoring = monitoringOpt.get();
+        Member member = monitoring.getMember();
+        boolean isMember = (member != null);
+        boolean onboardingCompleted;
+
+        if (isMember) {
+            // 회원: Member의 gender와 ageRange 확인
+            onboardingCompleted = (member.getGender() != null && member.getAgeRange() != null);
+            log.info("[ONBOARDING] Member check - Device: {}, MemberId: {}, Completed: {}",
+                    deviceNumber, member.getId(), onboardingCompleted);
+        } else {
+            // 비회원: Monitoring의 onboardingCompleted 확인
+            onboardingCompleted = monitoring.getOnboardingCompleted();
+            log.info("[ONBOARDING] Non-member check - Device: {}, Completed: {}",
+                    deviceNumber, onboardingCompleted);
+        }
+
+        return ResOnboardingStatusDto.builder()
+                .deviceNumber(deviceNumber)
+                .onboardingCompleted(onboardingCompleted)
+                .requiresOnboarding(!onboardingCompleted)
+                .isMember(isMember)
+                .build();
+    }
+
+    /**
+     * 비회원 온보딩 정보 저장
+     * Monitoring에 gender, ageRange, onboardingCompleted를 저장
+     */
+    @Transactional
+    public void saveNonMemberOnboarding(ReqSaveOnboardingDto dto) {
+        String deviceNumber = dto.getDeviceNumber();
+
+        Gender gender = Gender.fromString(dto.getGender())
+                .orElseThrow(() -> new CustomApiException("Invalid Gender Type"));
+        AgeRange ageRange = AgeRange.fromString(dto.getAgeRange())
+                .orElseThrow(() -> new CustomApiException("Invalid Age Range Type"));
+
+        Monitoring monitoring = monitoringRepository.findByDeviceNumber(deviceNumber)
+                .orElseGet(() -> {
+                    // 기기 정보가 없으면 새로 생성
+                    Monitoring newMonitoring = Monitoring.builder()
+                            .deviceNumber(deviceNumber)
+                            .count(0L)
+                            .build();
+                    return monitoringRepository.save(newMonitoring);
+                });
+
+        // 이미 회원인 경우 에러
+        if (monitoring.getMember() != null) {
+            throw new CustomApiException("이미 회원으로 등록된 기기입니다. 회원 온보딩 API를 사용하세요.");
+        }
+
+        // 온보딩 정보 저장
+        monitoring.saveOnboardingInfo(gender, ageRange);
+        monitoringRepository.save(monitoring);
+
+        log.info("[ONBOARDING] Non-member onboarding saved - Device: {}, Gender: {}, AgeRange: {}",
+                deviceNumber, gender, ageRange);
     }
 }


### PR DESCRIPTION
## 📌 작업 개요
- 기기 번호 기반 온보딩 시스템 구현
- 비회원도 온보딩 가능하며, 로그인 시 자동으로 회원 정보에 병합
- 한 사용자가 여러 기기를 사용하더라도, 한 번 온보딩을 완료하면 모든 기기에서 온보딩 스킵

### 주요 변경사항

#### 1. Monitoring 엔티티 확장
  - `onboarding_completed`: 온보딩 완료 여부 (boolean, NOT NULL, default false)
  - `gender`: 성별 정보 (varchar)
  - `age_range`: 연령대 정보 (varchar)

  #### 2. 새로운 API 추가
  - **GET** `/api/v2/monitoring/onboarding/status?deviceNumber={deviceNumber}` - 온보딩 상태 확인 API
  - **POST** `/api/v2/monitoring/onboarding` - 비회원 온보딩 저장 API

  #### 3. 기존 API 수정
  - **POST** `/api/v2/members/onboarding` - deviceNumber 필드 추가 및 모든 기기 동기화 기능 추가

  #### 4. 로그인 시 자동 병합
  - 비회원 온보딩 데이터가 로그인 시 자동으로 Member로 복사
  - 해당 회원의 모든 기기가 온보딩 완료 상태로 동기화

  ### 동작 플로우
  1. **비회원 → 온보딩 → 로그인**: 비회원 온보딩 후 로그인 시 자동 병합, 새 기기에서도 온보딩 스킵
  2. **로그인 → 온보딩**: 회원 온보딩 저장 시 모든 기기 자동 동기화
  3. **이미 온보딩 완료한 사용자**: 온보딩 스킵하고 홈으로 이동

## 이슈번호
- #61 

  ## ✨ 기타 참고 사항
  ### 데이터베이스 마이그레이션 필요
  배포 전에 다음 SQL을 운영 DB에서 실행해야 합니다:
  ```sql
  ALTER TABLE monitoring ADD COLUMN IF NOT EXISTS onboarding_completed BOOLEAN;
  ALTER TABLE monitoring ADD COLUMN IF NOT EXISTS gender VARCHAR(255);
  ALTER TABLE monitoring ADD COLUMN IF NOT EXISTS age_range VARCHAR(255);

  UPDATE monitoring SET onboarding_completed = false WHERE onboarding_completed IS NULL;

  ALTER TABLE monitoring ALTER COLUMN onboarding_completed SET NOT NULL;
  ALTER TABLE monitoring ALTER COLUMN onboarding_completed SET DEFAULT false;

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 이슈번호가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.