### PR TITLE
[#18] fix: 토큰 관련 수정

### DIFF
--- a/src/main/java/com/application/common/Constant.java
+++ b/src/main/java/com/application/common/Constant.java
@@ -8,8 +8,11 @@ public class Constant {
     public final static int NEED_REFRESH_TOKEN_CODE = -2;
     public final static int ERROR_CODE = -1;
 
-    public final static long REFRESH_EXPIRED_TIME = 14*24*60*60L;
-    public final static long BLACKLIST_EXPIRED_TIME = 15 * 60L;
+    // JWT 토큰 만료 시간 (밀리초)
+    public final static long ACCESS_TOKEN_EXPIRATION = 60 * 60 * 1000L; // 1시간
+    public final static long REFRESH_TOKEN_EXPIRATION = 14 * 24 * 60 * 60 * 1000L; // 14일
+    public final static long BLACKLIST_EXPIRATION = 60 * 60 * 1000L; // 1시간
+    public final static long BLACKLIST_CLEANUP_INTERVAL = 15 * 60 * 1000L; // 15분
 
 
     public final static int LITTLE_ALCHOL_MIN = 0;

--- a/src/main/java/com/application/common/Constant.java
+++ b/src/main/java/com/application/common/Constant.java
@@ -9,8 +9,10 @@ public class Constant {
     public final static int ERROR_CODE = -1;
 
     // JWT 토큰 만료 시간 (밀리초)
-    public final static long ACCESS_TOKEN_EXPIRATION = 60 * 60 * 1000L; // 1시간
-    public final static long REFRESH_TOKEN_EXPIRATION = 14 * 24 * 60 * 60 * 1000L; // 14일
+    public final static long ACCESS_TOKEN_EXPIRATION = 1 * 60 * 1000L; // 1분
+    public final static long REFRESH_TOKEN_EXPIRATION = 5 * 60 * 1000L; // 5분
+    // public final static long ACCESS_TOKEN_EXPIRATION = 60 * 60 * 1000L; // 1시간
+    // public final static long REFRESH_TOKEN_EXPIRATION = 14 * 24 * 60 * 60 * 1000L; // 14일
     public final static long BLACKLIST_EXPIRATION = 60 * 60 * 1000L; // 1시간
     public final static long BLACKLIST_CLEANUP_INTERVAL = 15 * 60 * 1000L; // 15분
 

--- a/src/main/java/com/application/common/auth/JWTAccessTokenBlackListService.java
+++ b/src/main/java/com/application/common/auth/JWTAccessTokenBlackListService.java
@@ -29,8 +29,9 @@ public class JWTAccessTokenBlackListService {
     }
 
 
-    @Scheduled(fixedRate = Constant.BLACKLIST_EXPIRED_TIME)
+    @Scheduled(fixedRate = Constant.BLACKLIST_CLEANUP_INTERVAL)
     public void blackListExpired(){
+        long blacklistExpirationMinutes = Constant.BLACKLIST_EXPIRATION / (60 * 1000);
 
         List<String> keys = jwtAccessBlackListStore.findAllKeySet();
         for (String key : keys) {
@@ -38,7 +39,7 @@ public class JWTAccessTokenBlackListService {
             LocalDateTime startTime = dto.getCreateTime();
             Duration duration = Duration.between(startTime, LocalDateTime.now());
 
-            if(duration.toMinutes() > 60){
+            if(duration.toMinutes() > blacklistExpirationMinutes){
                 deleteAccessTokeFromBlackList(key);
             }
 

--- a/src/main/java/com/application/common/auth/JWTStoreService.java
+++ b/src/main/java/com/application/common/auth/JWTStoreService.java
@@ -44,10 +44,11 @@ public class JWTStoreService {
         }
     }
 
-    @Scheduled(fixedRate = Constant.REFRESH_EXPIRED_TIME) // 2주관리
+    @Scheduled(fixedRate = Constant.REFRESH_TOKEN_EXPIRATION) // Refresh token 만료 주기로 스케줄링
     public void isRefreshExpired(){
+        long refreshTokenExpirationMinutes = Constant.REFRESH_TOKEN_EXPIRATION / (60 * 1000);
         jwtRefreshStore.getJwtStore().entrySet().removeIf(entry ->
-                Duration.between(entry.getValue().getCreateTime(), LocalDateTime.now()).toMinutes() > 14* 24* 60);
+                Duration.between(entry.getValue().getCreateTime(), LocalDateTime.now()).toMinutes() > refreshTokenExpirationMinutes);
     }
 
 }

--- a/src/main/java/com/application/common/auth/jwt/JWTFilter.java
+++ b/src/main/java/com/application/common/auth/jwt/JWTFilter.java
@@ -94,7 +94,13 @@ public class JWTFilter extends OncePerRequestFilter {
 
             // 칵테일 반응 API (인증 필요)
             "^/api/v2/cocktails/[0-9]+/reactions$",     // 칵테일 반응 조회/토글
-            "^/onz/api/v2/cocktails/[0-9]+/reactions$"  // 칵테일 반응 (onz 경로)
+            "^/onz/api/v2/cocktails/[0-9]+/reactions$", // 칵테일 반응 (onz 경로)
+
+            // 칵테일 북마크 API (인증 필요)
+            "^/api/v2/cocktails/[0-9]+/bookmarks$",     // 칵테일 북마크 토글
+            "^/api/v2/cocktails/bookmarks$",            // 내 북마크 목록 조회
+            "^/onz/api/v2/cocktails/[0-9]+/bookmarks$", // 칵테일 북마크 토글 (onz 경로)
+            "^/onz/api/v2/cocktails/bookmarks$"         // 내 북마크 목록 조회 (onz 경로)
     );
 
     // [기존 방식 : jwt 예외 필터 적용 - 주석 처리]

--- a/src/main/java/com/application/common/auth/jwt/JWTUtil.java
+++ b/src/main/java/com/application/common/auth/jwt/JWTUtil.java
@@ -1,5 +1,6 @@
 package com.application.common.auth.jwt;
 
+import com.application.common.Constant;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import org.springframework.beans.factory.annotation.Value;
@@ -61,7 +62,7 @@ public class JWTUtil {
                 .claim("credentialId", credentialId)
                 .claim("role", role)
                 .issuedAt(new Date(System.currentTimeMillis()))
-                .expiration(new Date(System.currentTimeMillis()+ 60 * 60 * 1000L))
+                .expiration(new Date(System.currentTimeMillis() + Constant.ACCESS_TOKEN_EXPIRATION))
                 .signWith(secretKey)
                 .compact();
 
@@ -74,7 +75,7 @@ public class JWTUtil {
                 .claim("credentialId", credentialId)
                 .claim("role", role)
                 .issuedAt(new Date(System.currentTimeMillis()))
-                .expiration(new Date(System.currentTimeMillis()+ 14 * 24 * 60 * 60 * 1000L))
+                .expiration(new Date(System.currentTimeMillis() + Constant.REFRESH_TOKEN_EXPIRATION))
                 .signWith(secretKey)
                 .compact();
 


### PR DESCRIPTION
## 📌 작업 개요
- JWT 만료 시간 수정 (access 1분, refresh 5분)
- 토큰 시간을 기존 하드코딩에서 Constant 에서 관리하도록 수정
- 북마크 api에 jwt 인증 적용

## 이슈번호
- #18 

## ✨ 기타 참고 사항

  ### 1. JWT 토큰 만료 시간 중앙 관리
  - 하드코딩된 토큰 만료 시간을 `Constant.java`로 통합
  - Access Token: 1분 (테스트용, 기존 1시간은 주석 처리)
  - Refresh Token: 5분 (테스트용, 기존 14일은 주석 처리)
  - Blacklist 관련 시간도 상수로 관리

  **변경된 파일:**
  - `Constant.java`: 토큰 만료 시간 상수 추가
  - `JWTUtil.java`: 하드코딩된 만료 시간을 Constant 참조로 변경
  - `JWTStoreService.java`: Constant 참조로 변경
  - `JWTAccessTokenBlackListService.java`: Constant 참조로 변경
  - `application.yml`: 추가했던 토큰 설정 제거 (Constant 방식으로 변경)

  ### 2. 북마크 API JWT 인증 적용
  북마크 API가 인증 없이 접근 가능한 문제 수정

  **증상:**
  - 토큰 만료 시 북마크 API 호출 시 `customOAuth2User is null` NullPointerException 발생
  - 북마크 API가 Public 경로로 인식되어 JWT 검증을 거치지 않음

  **해결:**
  - `JWTFilter.java`의 `REQUIRE_AUTH_PATH_PATTERNS`에 북마크 경로 추가
    - `^/api/v2/cocktails/[0-9]+/bookmarks$` (북마크 토글)
    - `^/api/v2/cocktails/bookmarks$` (내 북마크 목록)
    - onz 경로 포함

  **동작:**
  - 토큰 없이 호출 → 400 Bad Request
  - 만료된 토큰 → 401 Unauthorized (code: -2)
  - 유효한 토큰 → 정상 처리

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 이슈번호가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.


  