### PR TITLE
[#72] fix: 즐겨찾기 목록 조회 응답 개선 및 테스트 API 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,8 @@ out/
 /src/main/resources/*.properties
 /src/test/resources/*.properties
 
+### Test Files ###
+# 로컬 JWT 테스트용 파일
+/src/main/java/com/application/test/
+
 .env

--- a/src/main/java/com/application/domain/cocktail/controller/CocktailBookmarkController.java
+++ b/src/main/java/com/application/domain/cocktail/controller/CocktailBookmarkController.java
@@ -1,10 +1,13 @@
 package com.application.domain.cocktail.controller;
 
 import com.application.common.auth.dto.oauth2Dto.CustomOAuth2User;
+import com.application.common.auth.jwt.JWTUtil;
 import com.application.common.response.ResponseDto;
+import com.application.domain.cocktail.dto.response.BookmarkListResponse;
 import com.application.domain.cocktail.dto.response.BookmarkToggleResponse;
 import com.application.domain.cocktail.dto.response.CocktailResponseDto;
 import com.application.domain.cocktail.service.CocktailBookmarkService;
+import com.application.domain.member.entity.Member;
 import com.application.domain.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -25,6 +28,7 @@ public class CocktailBookmarkController {
 
     private final CocktailBookmarkService bookmarkService;
     private final MemberService memberService;
+    private final JWTUtil jwtUtil;
 
     /**
      * 즐겨찾기 토글 (추가/삭제)
@@ -63,20 +67,30 @@ public class CocktailBookmarkController {
      */
     @Operation(
             summary = "내가 즐겨찾기한 칵테일 목록 조회",
-            description = "로그인한 사용자가 즐겨찾기한 칵테일 목록을 최근 즐겨찾기 순서대로 조회합니다.",
+            description = "로그인한 사용자가 즐겨찾기한 칵테일 목록을 최근 즐겨찾기 순서대로 조회합니다. " +
+                    "응답에는 사용자 ID(memberId, credentialId)와 즐겨찾기한 칵테일 목록이 포함됩니다.",
             security = @SecurityRequirement(name = "bearerAuth")
     )
     @GetMapping("/bookmarks")
-    public ResponseEntity<ResponseDto<List<CocktailResponseDto>>> getMyBookmarks(
+    public ResponseEntity<ResponseDto<BookmarkListResponse>> getMyBookmarks(
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User
     ) {
-        Long memberId = memberService.getMemberByCredentialId(customOAuth2User.getCredentialId()).getId();
+        String credentialId = customOAuth2User.getCredentialId();
+        Member member = memberService.getMemberByCredentialId(credentialId);
+        Long memberId = member.getId();
 
         List<CocktailResponseDto> bookmarkedCocktails =
                 bookmarkService.getMyBookmarkedCocktails(memberId);
 
+        BookmarkListResponse response = BookmarkListResponse.builder()
+                .memberId(memberId)
+                .credentialId(credentialId)
+                .totalCount(bookmarkedCocktails.size())
+                .cocktails(bookmarkedCocktails)
+                .build();
+
         return new ResponseEntity<>(
-                ResponseDto.onSuccess("즐겨찾기 목록 조회 성공", bookmarkedCocktails),
+                ResponseDto.onSuccess("즐겨찾기 목록 조회 성공", response),
                 HttpStatus.OK
         );
     }

--- a/src/main/java/com/application/domain/cocktail/controller/CocktailBookmarkController.java
+++ b/src/main/java/com/application/domain/cocktail/controller/CocktailBookmarkController.java
@@ -11,14 +11,18 @@ import com.application.domain.member.entity.Member;
 import com.application.domain.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/v2/cocktails")
@@ -93,5 +97,55 @@ public class CocktailBookmarkController {
                 ResponseDto.onSuccess("즐겨찾기 목록 조회 성공", response),
                 HttpStatus.OK
         );
+    }
+
+    /**
+     * [테스트 전용] JWT 토큰 생성
+     * POST /api/v2/cocktails/test/token
+     */
+    @Operation(
+            summary = "[테스트] JWT 토큰 생성",
+            description = "테스트용 JWT Access Token을 생성합니다. credentialId를 전달하면 해당 사용자의 토큰을 생성합니다."
+    )
+    @SecurityRequirements
+    @PostMapping("/test/token")
+    public ResponseEntity<ResponseDto<TestTokenResponse>> generateTestToken(
+            @RequestBody(required = false) TestTokenRequest request
+    ) {
+        String credentialId = (request != null && request.getCredentialId() != null)
+                ? request.getCredentialId()
+                : "test-user-123";
+
+        String uuid = UUID.randomUUID().toString();
+        String role = "ROLE_USER";
+
+        String accessToken = jwtUtil.createAccessJwt(uuid, credentialId, role);
+        String refreshToken = jwtUtil.createRefreshJwt(uuid, credentialId, role);
+
+        TestTokenResponse response = new TestTokenResponse();
+        response.setAccessToken(accessToken);
+        response.setRefreshToken(refreshToken);
+        response.setCredentialId(credentialId);
+        response.setMessage("Authorization 헤더에 'Bearer " + accessToken + "' 형식으로 추가하세요");
+
+        return new ResponseEntity<>(
+                ResponseDto.onSuccess("테스트 토큰 생성 성공", response),
+                HttpStatus.OK
+        );
+    }
+
+    @Getter
+    @Setter
+    public static class TestTokenRequest {
+        private String credentialId;
+    }
+
+    @Getter
+    @Setter
+    public static class TestTokenResponse {
+        private String accessToken;
+        private String refreshToken;
+        private String credentialId;
+        private String message;
     }
 }

--- a/src/main/java/com/application/domain/cocktail/controller/CocktailBookmarkController.java
+++ b/src/main/java/com/application/domain/cocktail/controller/CocktailBookmarkController.java
@@ -1,7 +1,6 @@
 package com.application.domain.cocktail.controller;
 
 import com.application.common.auth.dto.oauth2Dto.CustomOAuth2User;
-import com.application.common.auth.jwt.JWTUtil;
 import com.application.common.response.ResponseDto;
 import com.application.domain.cocktail.dto.response.BookmarkListResponse;
 import com.application.domain.cocktail.dto.response.BookmarkToggleResponse;
@@ -11,18 +10,14 @@ import com.application.domain.member.entity.Member;
 import com.application.domain.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/v2/cocktails")
@@ -32,7 +27,6 @@ public class CocktailBookmarkController {
 
     private final CocktailBookmarkService bookmarkService;
     private final MemberService memberService;
-    private final JWTUtil jwtUtil;
 
     /**
      * 즐겨찾기 토글 (추가/삭제)
@@ -97,55 +91,5 @@ public class CocktailBookmarkController {
                 ResponseDto.onSuccess("즐겨찾기 목록 조회 성공", response),
                 HttpStatus.OK
         );
-    }
-
-    /**
-     * [테스트 전용] JWT 토큰 생성
-     * POST /api/v2/cocktails/test/token
-     */
-    @Operation(
-            summary = "[테스트] JWT 토큰 생성",
-            description = "테스트용 JWT Access Token을 생성합니다. credentialId를 전달하면 해당 사용자의 토큰을 생성합니다."
-    )
-    @SecurityRequirements
-    @PostMapping("/test/token")
-    public ResponseEntity<ResponseDto<TestTokenResponse>> generateTestToken(
-            @RequestBody(required = false) TestTokenRequest request
-    ) {
-        String credentialId = (request != null && request.getCredentialId() != null)
-                ? request.getCredentialId()
-                : "test-user-123";
-
-        String uuid = UUID.randomUUID().toString();
-        String role = "ROLE_USER";
-
-        String accessToken = jwtUtil.createAccessJwt(uuid, credentialId, role);
-        String refreshToken = jwtUtil.createRefreshJwt(uuid, credentialId, role);
-
-        TestTokenResponse response = new TestTokenResponse();
-        response.setAccessToken(accessToken);
-        response.setRefreshToken(refreshToken);
-        response.setCredentialId(credentialId);
-        response.setMessage("Authorization 헤더에 'Bearer " + accessToken + "' 형식으로 추가하세요");
-
-        return new ResponseEntity<>(
-                ResponseDto.onSuccess("테스트 토큰 생성 성공", response),
-                HttpStatus.OK
-        );
-    }
-
-    @Getter
-    @Setter
-    public static class TestTokenRequest {
-        private String credentialId;
-    }
-
-    @Getter
-    @Setter
-    public static class TestTokenResponse {
-        private String accessToken;
-        private String refreshToken;
-        private String credentialId;
-        private String message;
     }
 }

--- a/src/main/java/com/application/domain/cocktail/dto/response/BookmarkListResponse.java
+++ b/src/main/java/com/application/domain/cocktail/dto/response/BookmarkListResponse.java
@@ -1,0 +1,15 @@
+package com.application.domain.cocktail.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class BookmarkListResponse {
+    private Long memberId;
+    private String credentialId;
+    private Integer totalCount;
+    private List<CocktailResponseDto> cocktails;
+}

--- a/src/main/java/com/application/domain/cocktail/service/CocktailBookmarkService.java
+++ b/src/main/java/com/application/domain/cocktail/service/CocktailBookmarkService.java
@@ -32,6 +32,8 @@ public class CocktailBookmarkService {
      */
     @Transactional
     public boolean toggleBookmark(Long memberId, Long cocktailId) {
+        log.info("[즐겨찾기 토글 시작] memberId={}, cocktailId={}", memberId, cocktailId);
+
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
         Cocktail cocktail = cocktailRepository.findById(cocktailId)
@@ -42,11 +44,15 @@ public class CocktailBookmarkService {
 
         if (existingBookmark.isEmpty()) {
             // 북마크 추가
-            createBookmark(member, cocktail);
+            log.info("[즐겨찾기 추가] memberId={}, cocktailId={}", memberId, cocktailId);
+            CocktailBookmark saved = createBookmark(member, cocktail);
+            log.info("[즐겨찾기 추가 완료] bookmarkId={}", saved.getId());
             return true; // 북마크됨
         } else {
             // 북마크 삭제
+            log.info("[즐겨찾기 삭제] bookmarkId={}", existingBookmark.get().getId());
             removeBookmark(existingBookmark.get());
+            log.info("[즐겨찾기 삭제 완료] memberId={}, cocktailId={}", memberId, cocktailId);
             return false; // 북마크 취소됨
         }
     }
@@ -57,8 +63,12 @@ public class CocktailBookmarkService {
      */
     @Transactional(readOnly = true)
     public List<CocktailResponseDto> getMyBookmarkedCocktails(Long memberId) {
+        log.info("[보관함 조회 시작] memberId={}", memberId);
+
         List<CocktailBookmark> bookmarks =
                 bookmarkRepository.findByMemberIdOrderByCreatedAtDesc(memberId);
+
+        log.info("[보관함 조회 완료] memberId={}, 결과 개수={}", memberId, bookmarks.size());
 
         return bookmarks.stream()
                 .map(bookmark -> CocktailResponseDto.from(bookmark.getCocktail()))
@@ -75,12 +85,12 @@ public class CocktailBookmarkService {
 
     // ===== Private Helper Methods =====
 
-    private void createBookmark(Member member, Cocktail cocktail) {
+    private CocktailBookmark createBookmark(Member member, Cocktail cocktail) {
         CocktailBookmark bookmark = CocktailBookmark.builder()
                 .member(member)
                 .cocktail(cocktail)
                 .build();
-        bookmarkRepository.save(bookmark);
+        return bookmarkRepository.save(bookmark);
     }
 
     private void removeBookmark(CocktailBookmark bookmark) {

--- a/src/main/java/com/application/test/TestTokenController.java
+++ b/src/main/java/com/application/test/TestTokenController.java
@@ -1,0 +1,70 @@
+package com.application.test;
+
+import com.application.common.auth.jwt.JWTUtil;
+import com.application.common.response.ResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/test")
+@RequiredArgsConstructor
+@Tag(name = "테스트용 API", description = "개발 환경 전용 테스트 API")
+public class TestTokenController {
+
+    private final JWTUtil jwtUtil;
+
+    @Operation(
+            summary = "[테스트] JWT 토큰 생성",
+            description = "테스트용 JWT Access Token을 생성합니다. credentialId를 전달하면 해당 사용자의 토큰을 생성합니다."
+    )
+    @SecurityRequirements
+    @PostMapping("/token")
+    public ResponseEntity<ResponseDto<TokenResponse>> generateTestToken(
+            @RequestBody(required = false) TokenRequest request
+    ) {
+        String credentialId = (request != null && request.getCredentialId() != null)
+                ? request.getCredentialId()
+                : "test-user-123";
+
+        String uuid = UUID.randomUUID().toString();
+        String role = "ROLE_USER";
+
+        String accessToken = jwtUtil.createAccessJwt(uuid, credentialId, role);
+        String refreshToken = jwtUtil.createRefreshJwt(uuid, credentialId, role);
+
+        TokenResponse response = new TokenResponse();
+        response.setAccessToken(accessToken);
+        response.setRefreshToken(refreshToken);
+        response.setCredentialId(credentialId);
+        response.setMessage("Authorization 헤더에 'Bearer " + accessToken + "' 형식으로 추가하세요");
+
+        return new ResponseEntity<>(
+                ResponseDto.onSuccess("테스트 토큰 생성 성공", response),
+                HttpStatus.OK
+        );
+    }
+
+    @Getter
+    @Setter
+    public static class TokenRequest {
+        private String credentialId;
+    }
+
+    @Getter
+    @Setter
+    public static class TokenResponse {
+        private String accessToken;
+        private String refreshToken;
+        private String credentialId;
+        private String message;
+    }
+}


### PR DESCRIPTION
  ## 📌 작업 개요
- 즐겨찾기 목록 조회 확인 및 반환 값에 현재 user id, 갯수 추가

## 이슈번호
- #72 

## ✨ 기타 참고 사항
- jwt 로컬 테스트 api는 다음 pr 때 삭제하겠습니다.

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 이슈번호가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.
