### PR TITLE
[#78] fix: 칵테일 반응 API 인증 및 역직렬화 버그 수정

### DIFF
--- a/src/main/java/com/application/domain/cocktail/controller/CocktailV2Controller.java
+++ b/src/main/java/com/application/domain/cocktail/controller/CocktailV2Controller.java
@@ -18,7 +18,6 @@ import com.application.domain.cocktail.enums.TasteLevel;
 
 import com.application.domain.cocktail.service.CocktailBookmarkService;
 import com.application.domain.cocktail.service.CocktailService;
-import com.application.domain.member.entity.ParsedMember;
 import com.application.domain.member.service.MemberService;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.Operation;
@@ -500,11 +499,11 @@ public class CocktailV2Controller implements CocktailV2ControllerDocs{
     @Override
     @Operation(summary = "칵테일 반응 조회", description = "🔒 **인증 필요** - 로그인한 사용자의 해당 칵테일에 대한 반응(좋아요/싫어요) 상태를 조회합니다.")
     @GetMapping("/{cocktailId}/reactions")
-    public ResponseEntity<ReactionRes> getMyReaction( // todo ReactionDto.Response 뭐임?
+    public ResponseEntity<ReactionRes> getMyReaction(
                                                       @PathVariable Long cocktailId,
-                                                      @AuthenticationPrincipal ParsedMember user
+                                                      @AuthenticationPrincipal CustomOAuth2User customOAuth2User
     ) {
-        Long memberId = Long.valueOf(user.getCredentialId());
+        Long memberId = memberService.getMemberByCredentialId(customOAuth2User.getCredentialId()).getId();
 
         ReactionRes response = cocktailService.getReactionStatus(memberId, cocktailId);
         return ResponseEntity.ok(response);
@@ -516,11 +515,9 @@ public class CocktailV2Controller implements CocktailV2ControllerDocs{
     public ResponseEntity<ReactionRes> toggleReaction(
             @PathVariable Long cocktailId,
             @RequestBody ReactionReq request,
-            @AuthenticationPrincipal ParsedMember user // JWT Filter에서 넣어준 유저 정보
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User
     ) {
-        // ParsedMember에 id가 없다면 credentialId로 조회하는 로직이 필요할 수 있음
-        // 여기서는 user 객체에 식별자가 있다고 가정
-        Long memberId = Long.valueOf(user.getCredentialId());
+        Long memberId = memberService.getMemberByCredentialId(customOAuth2User.getCredentialId()).getId();
 
         ReactionRes response = cocktailService.toggleReaction(memberId, cocktailId, request.getReactionType());
         return ResponseEntity.ok(response);

--- a/src/main/java/com/application/domain/cocktail/controller/CocktailV2ControllerDocs.java
+++ b/src/main/java/com/application/domain/cocktail/controller/CocktailV2ControllerDocs.java
@@ -1,8 +1,8 @@
 package com.application.domain.cocktail.controller;
 
+import com.application.common.auth.dto.oauth2Dto.CustomOAuth2User;
 import com.application.domain.cocktail.dto.request.ReactionReq;
 import com.application.domain.cocktail.dto.response.ReactionRes;
-import com.application.domain.member.entity.ParsedMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -500,8 +500,8 @@ public interface CocktailV2ControllerDocs {
 //    ResponseEntity<?> getCocktailTags(@RequestBody CocktailV2Controller.RequestTagType requestTagType);
 
     @Operation(summary = "내 반응 조회", description = "페이지 진입 시, 내가 이 칵테일에 어떤 버튼을 눌렀는지 확인합니다.")
-    ResponseEntity<ReactionRes> getMyReaction(@PathVariable Long cocktailId, @AuthenticationPrincipal ParsedMember user);
+    ResponseEntity<ReactionRes> getMyReaction(@PathVariable Long cocktailId, @AuthenticationPrincipal CustomOAuth2User customOAuth2User);
 
     @Operation(summary = "반응 토글 (추천/어려워요)", description = "버튼 클릭 시 호출. 이미 눌렀으면 취소, 다른 걸 누르면 스위칭됩니다.")
-    ResponseEntity<ReactionRes> toggleReaction(@PathVariable Long cocktailId, @RequestBody ReactionReq request, @AuthenticationPrincipal ParsedMember user);
+    ResponseEntity<ReactionRes> toggleReaction(@PathVariable Long cocktailId, @RequestBody ReactionReq request, @AuthenticationPrincipal CustomOAuth2User customOAuth2User);
 }

--- a/src/main/java/com/application/domain/cocktail/dto/request/ReactionReq.java
+++ b/src/main/java/com/application/domain/cocktail/dto/request/ReactionReq.java
@@ -1,6 +1,7 @@
 package com.application.domain.cocktail.dto.request;
 
 import com.application.domain.cocktail.enums.ReactionType;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -12,6 +13,7 @@ import lombok.NoArgsConstructor;
 @Schema(description = "반응(추천/어려워요) 요청 DTO")
 public class ReactionReq {
 
+    @JsonProperty("reactionType")
     @Schema(description = "반응 타입 (RECOMMEND: 추천해요, HARD: 조금 어려워요)", example = "RECOMMEND")
     private ReactionType reactionType;
 }


### PR DESCRIPTION
## 📌 작업 개요
- 칵테일 반응 토글/조회 API에서 `@AuthenticationPrincipal`의 타입 불일치로 인한 user null 문제 수정
- `credentialId`(String)를 `Long.valueOf()`로 변환하던 버그를 `memberService` 조회 방식으로 수정
- `ReactionReq` DTO에 `@JsonProperty` 추가하여 JSON 역직렬화 문제 해결

## 이슈 번호
- #78 

## ✨ 기타 참고 사항

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 이슈번호가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.