### PR TITLE
[#84] fix: 칵테일 상세 조회 북마크 여부 LAZY 로딩 버그 수정

### DIFF
--- a/PR_MESSAGE.md
+++ b/PR_MESSAGE.md
@@ -1,0 +1,56 @@
+---
+name: 커스텀 이슈 템플릿
+about: 개발 작업을 위한 템플릿
+title: "[이슈 번호] fix: 칵테일 상세 조회 시 북마크 여부 LAZY 로딩 버그 수정"
+labels: 'bug'
+assignees: ''
+
+---
+
+[//]: # (feat: 새로운 기능)
+[//]: # (refactor: 기존 기능 자체는 변하지 않고 코드 개선 :: 로직만 변경)
+[//]: # (chore: 빌드 설정, 패키지 매니저 설정 등, 주석제거 등 분류하기 어려운 자잘한 수정에 대한 커밋)
+[//]: # (fix: 버그 수정)
+[//]: # (style: 포맷팅, 세미콜론 누락, lint 수정 등)
+[//]: # (docs: 문서 추가 또는 수정)
+[//]: # (test: 테스트 코드)
+[//]: # (hotfix: 급한 수정 사항 반영 시 사용)
+
+## 📌 작업 개요
+# 이슈번호
+<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
+- 로그인한 사용자가 칵테일 상세 조회 시 `is_bookmarked`가 항상 `false`로 반환되는 버그 수정
+- LAZY 로딩 문제로 인해 `Cocktail.bookmarks` 컬렉션이 영속성 컨텍스트 종료 후 접근되어 발생한 문제
+- 북마크 여부를 직접 조회하는 방식으로 변경하여 성능 개선 및 안정성 확보
+
+### 주요 변경사항
+
+1. **CocktailService.getCocktailV2()**
+   - `@Transactional(readOnly = true)` 어노테이션 추가
+   - 북마크 여부를 `bookmarkRepository.existsByMemberIdAndCocktailId()` 메서드로 직접 조회
+   - `Cocktail.isBookmarkedBy()` 메서드 사용 중단 (LAZY 로딩 회피)
+
+2. **CocktailResponseDto**
+   - 새로운 팩토리 메서드 추가: `from(Cocktail, ReactionType, Integer, Integer, boolean)`
+   - 북마크 여부를 파라미터로 직접 전달받아 LAZY 로딩 문제 원천 차단
+
+### 기술적 개선사항
+
+- **성능**: bookmarks 컬렉션 전체 로딩 대신 EXISTS 쿼리 1회로 북마크 여부 확인
+- **안정성**: LazyInitializationException 위험 제거
+- **일관성**: 메서드 전체가 하나의 읽기 전용 트랜잭션으로 실행되어 데이터 일관성 보장
+
+## ✨ 기타 참고 사항
+<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
+- 비로그인 사용자의 경우 `is_bookmarked`는 항상 `false`로 반환
+- 기존 `Cocktail.isBookmarkedBy(userId)` 메서드는 남겨두었으나, 서비스 레이어에서는 더 이상 사용하지 않음
+- 다른 API에서 동일한 LAZY 로딩 패턴이 있는지 확인 필요 (예: 칵테일 목록 조회는 이미 다른 방식으로 처리 중)
+
+## ✅ PR 체크 리스트
+- [x] PR 템플릿에 맞추어 작성했어요.
+- [x] PR에 적절한 라벨을 선택했어요.
+- [x] 이슈번호가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
+- [ ] 변경 내용에 대한 테스트를 진행했어요.
+- [ ] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
+- [x] 로컬 서버에서 정상 동작을 확인했어요.
+- [x] 불필요한 코드/주석 삭제했어요.

--- a/src/main/java/com/application/domain/cocktail/controller/CocktailV2Controller.java
+++ b/src/main/java/com/application/domain/cocktail/controller/CocktailV2Controller.java
@@ -249,24 +249,10 @@ public class CocktailV2Controller implements CocktailV2ControllerDocs{
     @SecurityRequirements
     @GetMapping("/detail")
     public ResponseEntity<ResponseDto<CocktailResponseDto>> getCocktail(
-//    public ResponseEntity<ResponseDto<CocktailDetailResponseDto>> getCocktail(
             @Parameter(example = "1")
             @RequestParam Long cocktailId,
             @AuthenticationPrincipal(errorOnInvalidType = false) CustomOAuth2User customOAuth2User
     ){
-//        // 1. 칵테일 엔티티 조회
-//        Cocktail cocktail = cocktailService.getCocktailV2Entity(cocktailId);
-//
-//        // 2. 북마크 여부 확인 (로그인한 사용자만)
-//        Boolean isBookmarked = null;
-//        if (customOAuth2User != null) {
-//            Long memberId = memberService.getMemberByCredentialId(customOAuth2User.getCredentialId()).getId();
-//            isBookmarked = bookmarkService.isBookmarked(memberId, cocktailId);
-//        }
-//
-//        // 3. DTO 변환 (북마크 여부 포함)
-//        CocktailDetailResponseDto response = CocktailDetailResponseDto.from(cocktail, isBookmarked);
-
         CocktailResponseDto cocktail = cocktailService.getCocktailV2(cocktailId, customOAuth2User);
 
         return new ResponseEntity<>(

--- a/src/main/java/com/application/domain/cocktail/dto/response/CocktailResponseDto.java
+++ b/src/main/java/com/application/domain/cocktail/dto/response/CocktailResponseDto.java
@@ -139,6 +139,51 @@ public record CocktailResponseDto(
         );
     }
 
+    // 엔티티를 DTO로 변환하는 정적 팩토리 메서드 (반응 정보 + 북마크 여부 직접 지정)
+    public static CocktailResponseDto from(Cocktail cocktail, ReactionType myReaction, Integer recommendCount, Integer hardCount, boolean isBookmarked) {
+
+        // 재료 리스트로 전달하도록 수정
+        String rawIngredientsText = cocktail.getIngredientsText();
+        List<String> ingredients = (rawIngredientsText != null && !rawIngredientsText.isEmpty())
+                ? Arrays.stream(rawIngredientsText.split(","))
+                .map(String::trim) // 공백 제거
+                .toList()
+                : List.of(); // 값이 없으면 빈 리스트 반환
+
+        return new CocktailResponseDto(
+                cocktail.getId(),
+                cocktail.getKorName(),
+                cocktail.getEngName(),
+                cocktail.getAbvBand(),
+                cocktail.getMaxAlcohol(),
+                cocktail.getMinAlcohol(),
+                cocktail.getOriginText(),
+                cocktail.getSeason(),
+                ingredients,
+                cocktail.getStyle(),
+                cocktail.getGlassType(),
+                cocktail.getGlassImageUrl(),
+                cocktail.getBase(),
+                cocktail.getImageUrl(),
+
+                // [매핑 로직] Entity List -> String List 변환
+                cocktail.getFlavors().stream()
+                        .map(CocktailFlavor::getFlavorName)
+                        .toList(),
+
+                cocktail.getMoods().stream()
+                        .map(CocktailMood::getMoodName)
+                        .toList(),
+
+                isBookmarked, // ⭐️ 북마크 여부를 직접 전달받음
+
+                // 반응 정보
+                myReaction,
+                recommendCount != null ? recommendCount : cocktail.getRecommendCount(),
+                hardCount != null ? hardCount : cocktail.getHardCount()
+        );
+    }
+
     // 엔티티를 DTO로 변환하는 정적 팩토리 메서드 (북마크 여부만 지정)
     public static CocktailResponseDto from(Cocktail cocktail, boolean isBookmarked) {
 

--- a/src/main/java/com/application/domain/cocktail/service/CocktailService.java
+++ b/src/main/java/com/application/domain/cocktail/service/CocktailService.java
@@ -260,6 +260,7 @@ public class CocktailService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
     public CocktailResponseDto getCocktailV2(Long cocktailId, CustomOAuth2User user) {
 
         // 랜덤 ID 생성 (1부터 105까지 포함)
@@ -276,24 +277,29 @@ public class CocktailService {
                 () -> new CustomApiException("칵테일이 존재하지 않습니다.")
         );
 
+        // 비로그인 사용자 처리
         if(user == null) {
-            return CocktailResponseDto.from(cocktail);
+            return CocktailResponseDto.from(cocktail, null, null, null, false);
         }
 
         String credentialId = user.getCredentialId();
         if (credentialId == null) {
-            return CocktailResponseDto.from(cocktail);
+            return CocktailResponseDto.from(cocktail, null, null, null, false);
         }
 
         Member member = memberRepository.findByCredentialId(credentialId);
+
+        // ⭐️ 북마크 여부를 직접 조회 (LAZY 로딩 문제 해결)
+        boolean isBookmarked = bookmarkRepository.existsByMemberIdAndCocktailId(member.getId(), cocktailId);
 
         // 반응 정보 조회
         ReactionType myReaction = reactionRepository.findByMemberIdAndCocktailId(member.getId(), cocktailId)
                 .map(CocktailReaction::getReactionType)
                 .orElse(null);
 
-        return CocktailResponseDto.from(cocktail, member.getId(), myReaction,
-                cocktail.getRecommendCount(), cocktail.getHardCount());
+        // ⭐️ 새로운 팩토리 메서드 사용: isBookmarked를 직접 전달
+        return CocktailResponseDto.from(cocktail, myReaction,
+                cocktail.getRecommendCount(), cocktail.getHardCount(), isBookmarked);
     }
 
     /**


### PR DESCRIPTION
## 이슈번호
- #84 

## 📌 작업 개요
<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 로그인한 사용자가 칵테일 상세 조회 시 `is_bookmarked`가 항상 `false`로 반환되는 버그 수정
- LAZY 로딩 문제로 인해 `Cocktail.bookmarks` 컬렉션이 영속성 컨텍스트 종료 후 접근되어 발생한 문제
- 북마크 여부를 직접 조회하는 방식으로 변경하여 성능 개선 및 안정성 확보

### 주요 변경사항

1. **CocktailService.getCocktailV2()**
   - `@Transactional(readOnly = true)` 어노테이션 추가
   - 북마크 여부를 `bookmarkRepository.existsByMemberIdAndCocktailId()` 메서드로 직접 조회
   - `Cocktail.isBookmarkedBy()` 메서드 사용 중단 (LAZY 로딩 회피)

2. **CocktailResponseDto**
   - 새로운 팩토리 메서드 추가: `from(Cocktail, ReactionType, Integer, Integer, boolean)`
   - 북마크 여부를 파라미터로 직접 전달받아 LAZY 로딩 문제 원천 차단

### 기술적 개선사항

- **성능**: bookmarks 컬렉션 전체 로딩 대신 EXISTS 쿼리 1회로 북마크 여부 확인
- **안정성**: LazyInitializationException 위험 제거
- **일관성**: 메서드 전체가 하나의 읽기 전용 트랜잭션으로 실행되어 데이터 일관성 보장

## ✨ 기타 참고 사항
<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 비로그인 사용자의 경우 `is_bookmarked`는 항상 `false`로 반환
- 기존 `Cocktail.isBookmarkedBy(userId)` 메서드는 남겨두었으나, 서비스 레이어에서는 더 이상 사용하지 않음
- 다른 API에서 동일한 LAZY 로딩 패턴이 있는지 확인 필요 (예: 칵테일 목록 조회는 이미 다른 방식으로 처리 중)

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 이슈번호가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.
