### PR TITLE
[#84] fix: 칵테일 상세 조회 북마크 여부 null 처리 및 JWT 선택적 인증 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ out/
 .env
 
 CLAUDE.md
+.claude

--- a/build.gradle
+++ b/build.gradle
@@ -23,9 +23,10 @@ repositories {
 	mavenCentral()
 }
 
-tasks.withType(Test) {
-	enabled = false
-}
+// 테스트 임시 활성화 (북마크 기능 테스트를 위해)
+//tasks.withType(Test) {
+//	enabled = false
+//}
 
 
 // --- QueryDSL 설정 ---
@@ -67,6 +68,9 @@ dependencies {
 
     // Postgresql
     runtimeOnly 'org.postgresql:postgresql'
+
+    // H2 (테스트용 인메모리 DB)
+    testRuntimeOnly 'com.h2database:h2'
 
 	//security
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/application/common/auth/jwt/JWTFilter.java
+++ b/src/main/java/com/application/common/auth/jwt/JWTFilter.java
@@ -103,6 +103,20 @@ public class JWTFilter extends OncePerRequestFilter {
             "^/onz/api/v2/cocktails/bookmarks$"         // 내 북마크 목록 조회 (onz 경로)
     );
 
+    // 선택적 인증 경로 (JWT 토큰이 있으면 검증하고, 없으면 익명 사용자로 통과)
+    private final static List<String> OPTIONAL_AUTH_PATH_PATTERNS = List.of(
+            "^/api/v2/cocktails$",                      // 칵테일 목록 조회 (북마크 여부 포함)
+            "^/api/v2/cocktails/detail$",               // 칵테일 상세 조회 (북마크 여부 포함)
+            "^/api/v2/cocktails/best$",                 // BEST 칵테일 조회 (북마크 여부 포함)
+            "^/api/v2/cocktails/recent$",               // 최근 칵테일 조회 (북마크 여부 포함)
+            "^/api/v2/cocktails/specific$",             // 특정 칵테일 조회 (북마크 여부 포함)
+            "^/onz/api/v2/cocktails$",                  // 칵테일 목록 조회 (onz 경로)
+            "^/onz/api/v2/cocktails/detail$",           // 칵테일 상세 조회 (onz 경로)
+            "^/onz/api/v2/cocktails/best$",             // BEST 칵테일 조회 (onz 경로)
+            "^/onz/api/v2/cocktails/recent$",           // 최근 칵테일 조회 (onz 경로)
+            "^/onz/api/v2/cocktails/specific$"          // 특정 칵테일 조회 (onz 경로)
+    );
+
     // [기존 방식 : jwt 예외 필터 적용 - 주석 처리]
 //    @Override
 //    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -178,7 +192,31 @@ public class JWTFilter extends OncePerRequestFilter {
 
         String uri = request.getRequestURI();
 
-        // 인증이 필요한 경로인지 확인
+        // 1. 선택적 인증 경로 처리 (JWT 토큰이 있으면 검증, 없으면 통과)
+        if (isOptionalAuthPath(uri)) {
+            log.info("Optional auth path: {}", uri);
+            String accessToken = getAccessToken(request);
+
+            // JWT 토큰이 있으면 검증하고 SecurityContext 설정
+            if (accessToken != null && !jwtUtil.isAccessExpired(accessToken)) {
+                String uuid = jwtUtil.getUUID(accessToken);
+                String blackListToken = jwtAccessTokenBlackListService.getAccessTokenFromBlackList(uuid);
+
+                if (blackListToken == null) {
+                    setSecurityContext(jwtUtil, accessToken);
+                    log.info("Optional path - SecurityContext set for accessToken UUID: {}", uuid);
+                } else {
+                    log.info("Optional path - Access Token is blacklisted, proceed as anonymous");
+                }
+            } else {
+                log.info("Optional path - No valid accessToken, proceed as anonymous");
+            }
+
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 2. 인증이 필요한 경로인지 확인
         if (!isRequireAuthPath(uri)) {
             // 인증이 필요하지 않은 경로 -> 바로 통과
             log.info("Public path, skipping JWT validation: {}", uri);
@@ -186,7 +224,7 @@ public class JWTFilter extends OncePerRequestFilter {
             return;
         }
 
-        // 인증이 필요한 경로 -> JWT 토큰 검증
+        // 3. 인증이 필요한 경로 -> JWT 토큰 검증 (필수)
         log.info("Protected path, validating JWT: {}", uri);
 
         String accessToken = getAccessToken(request);
@@ -221,6 +259,11 @@ public class JWTFilter extends OncePerRequestFilter {
     // 인증이 필요한 경로인지 확인
     private boolean isRequireAuthPath(String uri) {
         return REQUIRE_AUTH_PATH_PATTERNS.stream().anyMatch(uri::matches);
+    }
+
+    // 선택적 인증 경로인지 확인
+    private boolean isOptionalAuthPath(String uri) {
+        return OPTIONAL_AUTH_PATH_PATTERNS.stream().anyMatch(uri::matches);
     }
 
     private void sendErrorResponse(HttpServletResponse response,int code,  int status, String message) throws IOException{

--- a/src/main/java/com/application/domain/cocktail/service/CocktailService.java
+++ b/src/main/java/com/application/domain/cocktail/service/CocktailService.java
@@ -202,6 +202,10 @@ public class CocktailService {
         }
 
         Member member = memberRepository.findByCredentialId(credentialId);
+        if (member == null) {
+            log.warn("Member not found for credentialId: {}", credentialId);
+            return cocktails.stream().map(CocktailResponseDto::from).toList();
+        }
 
         return cocktails.stream()
                 .map(cocktail -> CocktailResponseDto.from(cocktail, member.getId()))
@@ -228,6 +232,10 @@ public class CocktailService {
         }
 
         Member member = memberRepository.findByCredentialId(credentialId);
+        if (member == null) {
+            log.warn("Member not found for credentialId: {}", credentialId);
+            return cocktails.stream().map(CocktailResponseDto::from).toList();
+        }
 
         return cocktails.stream()
                 .map(cocktail -> CocktailResponseDto.from(cocktail, member.getId()))
@@ -254,6 +262,10 @@ public class CocktailService {
         }
 
         Member member = memberRepository.findByCredentialId(credentialId);
+        if (member == null) {
+            log.warn("Member not found for credentialId: {}", credentialId);
+            return cocktails.stream().map(CocktailResponseDto::from).toList();
+        }
 
         return cocktails.stream()
                 .map(cocktail -> CocktailResponseDto.from(cocktail, member.getId()))
@@ -283,11 +295,17 @@ public class CocktailService {
         }
 
         String credentialId = user.getCredentialId();
+        log.info("Credential ID: {}", credentialId); // 디버깅용 로그
         if (credentialId == null) {
+            log.warn("credentialId is null for user: {}", user.getName());
             return CocktailResponseDto.from(cocktail, null, null, null, false);
         }
 
         Member member = memberRepository.findByCredentialId(credentialId);
+        if (member == null) {
+            log.warn("Member not found for credentialId: {}", credentialId);
+            return CocktailResponseDto.from(cocktail, null, null, null, false);
+        }
 
         // ⭐️ 북마크 여부를 직접 조회 (LAZY 로딩 문제 해결)
         boolean isBookmarked = bookmarkRepository.existsByMemberIdAndCocktailId(member.getId(), cocktailId);

--- a/src/test/java/com/application/ApplicationTests.java
+++ b/src/test/java/com/application/ApplicationTests.java
@@ -2,8 +2,10 @@ package com.application;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class ApplicationTests {
 
 	@Test

--- a/src/test/java/com/application/domain/cocktail/controller/CocktailV2ControllerTest.java
+++ b/src/test/java/com/application/domain/cocktail/controller/CocktailV2ControllerTest.java
@@ -1,0 +1,197 @@
+package com.application.domain.cocktail.controller;
+
+import com.application.common.auth.jwt.JWTUtil;
+import com.application.domain.cocktail.entity.Cocktail;
+import com.application.domain.cocktail.entity.CocktailBookmark;
+import com.application.domain.cocktail.enums.AbvLevel;
+import com.application.domain.cocktail.repository.CocktailBookmarkRepository;
+import com.application.domain.cocktail.repository.CocktailRepository;
+import com.application.domain.member.entity.Member;
+import com.application.domain.member.enums.Role;
+import com.application.domain.member.enums.SocialLogin;
+import com.application.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@ActiveProfiles("test")
+@DisplayName("칵테일 V2 컨트롤러 테스트")
+class CocktailV2ControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private CocktailRepository cocktailRepository;
+
+    @Autowired
+    private CocktailBookmarkRepository bookmarkRepository;
+
+    @Autowired
+    private JWTUtil jwtUtil;
+
+    private Member testMember;
+    private Cocktail testCocktail;
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() {
+        // 1. 테스트 회원 생성 (ID=1)
+        testMember = Member.builder()
+                .credentialId("test-credential-id")
+                .name("테스트유저")
+                .nickname("테스터")
+                .email("test@example.com")
+                .socialLogin(SocialLogin.KAKAO)
+                .profile("https://example.com/profile.jpg")
+                .role(Role.USER)
+                .ageTerm(true)
+                .serviceTerm(true)
+                .marketingTerm(false)
+                .adTerm(false)
+                .build();
+        testMember = memberRepository.save(testMember);
+
+        // 2. 테스트 칵테일 생성 (ID=5)
+        testCocktail = Cocktail.builder()
+                .korName("마티니")
+                .engName("Martini")
+                .abvBand(AbvLevel.STRONG)
+                .maxAlcohol(40)
+                .minAlcohol(35)
+                .originText("클래식 칵테일")
+                .season("사계절")
+                .ingredientsText("진, 베르무트")
+                .style("클래식")
+                .glassType("마티니 글라스")
+                .glassImageUrl("https://example.com/glass.jpg")
+                .base("진")
+                .imageUrl("https://example.com/martini.jpg")
+                .moods(new ArrayList<>())
+                .flavors(new ArrayList<>())
+                .tags(new ArrayList<>())
+                .recommendCount(10)
+                .hardCount(2)
+                .build();
+        testCocktail = cocktailRepository.save(testCocktail);
+
+        // 3. 북마크 생성 (user_id=1, cocktail_id=5)
+        CocktailBookmark bookmark = CocktailBookmark.builder()
+                .member(testMember)
+                .cocktail(testCocktail)
+                .build();
+        bookmarkRepository.save(bookmark);
+
+        // 4. JWT 토큰 생성
+        accessToken = jwtUtil.createAccessJwt(
+                "test-session-id",
+                testMember.getCredentialId(),
+                testMember.getRole()
+        );
+    }
+
+    @Test
+    @DisplayName("로그인한 사용자가 북마크한 칵테일 상세 조회 시 is_bookmarked=true 반환")
+    void getCocktailDetail_WithBookmark_ReturnsIsBookmarkedTrue() throws Exception {
+        // given
+        Long cocktailId = testCocktail.getId();
+
+        // when & then
+        mockMvc.perform(get("/api/v2/cocktails/detail")
+                        .param("cocktailId", String.valueOf(cocktailId))
+                        .header("Authorization", "Bearer " + accessToken))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(1))
+                .andExpect(jsonPath("$.msg").value("칵테일 조회 성공 (v2)"))
+                .andExpect(jsonPath("$.data.id").value(cocktailId))
+                .andExpect(jsonPath("$.data.kor_name").value("마티니"))
+                .andExpect(jsonPath("$.data.is_bookmarked").value(true)); // ⭐️ 핵심: 북마크 여부 확인
+    }
+
+    @Test
+    @DisplayName("로그인한 사용자가 북마크하지 않은 칵테일 상세 조회 시 is_bookmarked=false 반환")
+    void getCocktailDetail_WithoutBookmark_ReturnsIsBookmarkedFalse() throws Exception {
+        // given - 다른 칵테일 생성 (북마크 없음)
+        Cocktail otherCocktail = Cocktail.builder()
+                .korName("모히또")
+                .engName("Mojito")
+                .abvBand(AbvLevel.WEAK)
+                .maxAlcohol(15)
+                .minAlcohol(10)
+                .originText("쿠바 칵테일")
+                .season("여름")
+                .ingredientsText("럼, 민트, 라임")
+                .style("라이트")
+                .glassType("하이볼 글라스")
+                .base("럼")
+                .imageUrl("https://example.com/mojito.jpg")
+                .moods(new ArrayList<>())
+                .flavors(new ArrayList<>())
+                .tags(new ArrayList<>())
+                .build();
+        otherCocktail = cocktailRepository.save(otherCocktail);
+
+        // when & then
+        mockMvc.perform(get("/api/v2/cocktails/detail")
+                        .param("cocktailId", String.valueOf(otherCocktail.getId()))
+                        .header("Authorization", "Bearer " + accessToken))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(1))
+                .andExpect(jsonPath("$.data.id").value(otherCocktail.getId()))
+                .andExpect(jsonPath("$.data.kor_name").value("모히또"))
+                .andExpect(jsonPath("$.data.is_bookmarked").value(false)); // ⭐️ 북마크하지 않음
+    }
+
+    @Test
+    @DisplayName("비로그인 사용자가 칵테일 상세 조회 시 is_bookmarked=false 반환")
+    void getCocktailDetail_WithoutAuth_ReturnsIsBookmarkedFalse() throws Exception {
+        // given
+        Long cocktailId = testCocktail.getId();
+
+        // when & then - Authorization 헤더 없이 요청
+        mockMvc.perform(get("/api/v2/cocktails/detail")
+                        .param("cocktailId", String.valueOf(cocktailId)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(1))
+                .andExpect(jsonPath("$.data.id").value(cocktailId))
+                .andExpect(jsonPath("$.data.is_bookmarked").value(false)); // ⭐️ 비로그인은 항상 false
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 칵테일 조회 시 예외 발생")
+    void getCocktailDetail_NotFound_ThrowsException() throws Exception {
+        // given
+        Long nonExistentCocktailId = 99999L;
+
+        // when & then
+        mockMvc.perform(get("/api/v2/cocktails/detail")
+                        .param("cocktailId", String.valueOf(nonExistentCocktailId))
+                        .header("Authorization", "Bearer " + accessToken))
+                .andDo(print())
+                .andExpect(status().isBadRequest()) // CustomApiException은 400 BAD_REQUEST 반환
+                .andExpect(jsonPath("$.code").value(-1))
+                .andExpect(jsonPath("$.msg").value("잘못된 요청"));
+    }
+}

--- a/src/test/java/com/application/domain/cocktail/repository/CocktailRepositoryTest.java
+++ b/src/test/java/com/application/domain/cocktail/repository/CocktailRepositoryTest.java
@@ -34,9 +34,19 @@ class CocktailRepositoryTest {
 
         // 2. 데이터 준비 (초기값 0)
         Cocktail cocktail = Cocktail.builder()
-                .cocktailKR("모히또")
-                .cocktailEN("Mojito")
-                .maxAlcohol(10).minAlcohol(5)
+                .korName("모히또")
+                .engName("Mojito")
+                .maxAlcohol(10)
+                .minAlcohol(5)
+                .originText("동시성 테스트용")
+                .season("사계절")
+                .ingredientsText("럼, 민트")
+                .style("라이트")
+                .glassType("하이볼")
+                .base("럼")
+                .imageUrl("https://example.com/test.jpg")
+                .recommendCount(0)
+                .hardCount(0)
                 .build();
 
         // ★ 중요: saveAndFlush로 즉시 DB에 반영하여 다른 스레드가 볼 수 있게 함

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,19 +1,23 @@
 spring:
   datasource:
-    url: ${POSTGRE_url}
-    username: ${POSTGRE_USERNAME}
-    password: ${POSTGRE_PASSWORD}
-    driver-class-name: org.postgresql.Driver
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
 
   jpa:
-    database: postgresql
-    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    database: h2
+    database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
       ddl-auto: create-drop # 테스트용: 매번 새로 생성
     show-sql: true
     properties:
       hibernate:
         format_sql: true
+
+  h2:
+    console:
+      enabled: true
 
 logging:
   level:

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -4,64 +4,68 @@ logging.level.org.springframework.security=DEBUG
 spring.jackson.property-naming-strategy=SNAKE_CASE
 
 #jwt
-spring.jwt.secret=${JWT_SECRET}
+spring.jwt.secret=test-super-secret-key-for-testing-at-least-32-chars-long-here
 
 #log file path
-#  [mac : /var/log] || [window : C:/Logs]
 log.path=C:/Logs
 
-#Naver
+KAKAO_ID=test-kakao-id
+KAKAO_SECRET=test-kakao-secret
+NAVER_ID=test-naver-id
+NAVER_SECRET=test-naver-secret
+GOOGLE_ID=test-google-id
+GOOGLE_SECRET=test-google-secret
+APPLE_CLIENT_ID=test-apple-client-id
+APPLE_TEAM_ID=test-apple-team-id
+APPLE_SERVICE_ID=test-apple-service-id
+APPLE_KEY_ID=test-apple-key-id
+APPLE_PRIVATE_KEY=test-apple-private-key
+REDIRECT_HOST=localhost:8080
 
-#registration
 spring.security.oauth2.client.registration.naver.client-name=naver
-spring.security.oauth2.client.registration.naver.client-id=${NAVER_ID}
-spring.security.oauth2.client.registration.naver.client-secret=${NAVER_SECRET}
-#spring.security.oauth2.client.registration.naver.redirect-uri=https://${REDIRECT_HOST}/login/oauth2/code/naver
+spring.security.oauth2.client.registration.naver.client-id=test-naver-id
+spring.security.oauth2.client.registration.naver.client-secret=test-naver-secret
 spring.security.oauth2.client.registration.naver.redirect-uri=http://localhost:8080/login/oauth2/code/naver
 spring.security.oauth2.client.registration.naver.authorization-grant-type=authorization_code
 spring.security.oauth2.client.registration.naver.scope=name,email
 
-#provider
 spring.security.oauth2.client.provider.naver.authorization-uri=https://nid.naver.com/oauth2.0/authorize
 spring.security.oauth2.client.provider.naver.token-uri=https://nid.naver.com/oauth2.0/token
 spring.security.oauth2.client.provider.naver.user-info-uri=https://openapi.naver.com/v1/nid/me
 spring.security.oauth2.client.provider.naver.user-name-attribute=response
 
-
-#Google
 spring.security.oauth2.client.registration.google.client-name=google
-spring.security.oauth2.client.registration.google.client-id=${GOOGLE_ID}
-spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_SECRET}
-#spring.security.oauth2.client.registration.google.redirect-uri=https://${REDIRECT_HOST}/login/oauth2/code/google
+spring.security.oauth2.client.registration.google.client-id=test-google-id
+spring.security.oauth2.client.registration.google.client-secret=test-google-secret
 spring.security.oauth2.client.registration.google.redirect-uri=http://localhost:8080/login/oauth2/code/google
 spring.security.oauth2.client.registration.google.authorization-grant-type=authorization_code
 spring.security.oauth2.client.registration.google.scope=email,profile
 
-# Google OAuth2 Provider ??
 spring.security.oauth2.client.provider.google.authorization-uri=https://accounts.google.com/o/oauth2/auth
 spring.security.oauth2.client.provider.google.token-uri=https://oauth2.googleapis.com/token
 spring.security.oauth2.client.provider.google.user-info-uri=https://www.googleapis.com/oauth2/v1/userinfo
 spring.security.oauth2.client.provider.google.user-name-attribute=sub
 
+spring.security.oauth2.client.registration.kakao.client-name=kakao
+spring.security.oauth2.client.registration.kakao.client-id=test-kakao-id
+spring.security.oauth2.client.registration.kakao.client-secret=test-kakao-secret
+spring.security.oauth2.client.registration.kakao.redirect-uri=http://localhost:8080/login/oauth2/code/kakao
+spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.kakao.scope=profile_nickname,account_email
 
+spring.security.oauth2.client.provider.kakao.authorization-uri=https://kauth.kakao.com/oauth/authorize
+spring.security.oauth2.client.provider.kakao.token-uri=https://kauth.kakao.com/oauth/token
+spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
+spring.security.oauth2.client.provider.kakao.user-name-attribute=id
 
-#DB
-spring.datasource.url=jdbc:mariadb://${DB_HOST}/cocktail?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&useUnicode=true&connectionCollation=utf8mb4_unicode_ci
-spring.datasource.username=${DB_USER}
-spring.datasource.password=${DB_PASSWORD}
-spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
-spring.sql.init.mode=always
-#spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.security.oauth2.client.registration.apple.client-name=apple
+spring.security.oauth2.client.registration.apple.client-id=test-apple-id
+spring.security.oauth2.client.registration.apple.client-secret=test-apple-secret
+spring.security.oauth2.client.registration.apple.redirect-uri=http://localhost:8080/login/oauth2/code/apple
+spring.security.oauth2.client.registration.apple.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.apple.scope=name,email
 
-# HikariCP ??
-spring.datasource.hikari.maximum-pool-size=10
-spring.datasource.hikari.minimum-idle=2
-spring.datasource.hikari.idle-timeout=30000
-spring.datasource.hikari.connection-timeout=30000
-
-# JPA
-spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
-spring.jpa.hibernate.ddl-auto=update
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.format_sql=true
-spring.jpa.defer-datasource-initialization=true
+spring.security.oauth2.client.provider.apple.authorization-uri=https://appleid.apple.com/auth/authorize
+spring.security.oauth2.client.provider.apple.token-uri=https://appleid.apple.com/auth/token
+spring.security.oauth2.client.provider.apple.user-info-uri=https://appleid.apple.com/auth/userinfo
+spring.security.oauth2.client.provider.apple.user-name-attribute=sub


### PR DESCRIPTION
 ## 관련 이슈번호
- #84

## 📌 작업 개요

  ### 문제 상황
  로그인한 사용자가 북마크한 칵테일을 조회할 때 `isBookmarked`가 항상 `false`로 반환되는 버그 수정

  ### 원인 분석
  1. **Member null 체크 누락**: `credentialId`는 존재하나 DB에서 Member를 찾지 못하는 경우 NPE 발생 가능
  2. **JWT 필터 미적용**: `/api/v2/cocktails/detail` 등 칵테일 조회 API가 JWT 필터를 통과하지 않아 인증 정보 누락

  ### 해결 방안
  1. **CocktailService 개선**
     - `member` null 체크 로직 추가 (4개 메서드)
     - `credentialId` 디버깅 로그 추가
     - 대상 메서드: `getCocktailV2`, `getBestCocktails`, `getRecentCocktails`, `getSpecificCocktailsV2`

  2. **JWTFilter 선택적 인증 경로 추가**
     - 칵테일 조회 API에 Optional Auth 패턴 적용
     - JWT 토큰이 있으면 인증 처리, 없으면 익명 사용자로 통과
     - 적용 경로: `/api/v2/cocktails$`, `/api/v2/cocktails/detail$`, `/api/v2/cocktails/best$`, `/api/v2/cocktails/recent$`, `/api/v2/cocktails/specific$`

  3. **통합 테스트 추가**
     - 북마크 여부 검증 테스트 케이스 4개 추가
     - H2 인메모리 DB 기반 테스트 환경 구축
     - 모든 테스트 통과 확인 ✅

  ### 변경 파일
  - `CocktailService.java`: member null 체크 추가 (4개 메서드)
  - `JWTFilter.java`: 선택적 인증 경로 패턴 및 로직 추가
  - `CocktailV2ControllerTest.java`: 북마크 기능 통합 테스트 4개 추가
  - `build.gradle`: 테스트 활성화, H2 의존성 추가
  - `application-test.yml`: H2 DB 설정
  - `application.properties` (test): JWT 시크릿 및 OAuth2 더미 설정

  ## ✨ 기타 참고 사항
  - 기존 커밋(`3e904eb`)에서 LAZY 로딩 문제를 해결했으나, 근본 원인인 JWT 인증 및 member null 체크가 누락되어 재발생
  - 이번 수정으로 다음 시나리오 모두 정상 처리:
    - ✅ 로그인 + 북마크 O → `isBookmarked: true`
    - ✅ 로그인 + 북마크 X → `isBookmarked: false`
    - ✅ 비로그인 → `isBookmarked: false`
    - ✅ credentialId 존재하나 Member 없음 → `isBookmarked: false` (경고 로그)

  ## ✅ PR 체크 리스트
  - [x] PR 템플릿에 맞추어 작성했어요.
  - [x] PR에 적절한 라벨을 선택했어요.
  - [x] 이슈번호가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
  - [x] 변경 내용에 대한 테스트를 진행했어요. (통합 테스트 4개 모두 통과)
  - [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요. (테스트 환경만 수정)
  - [x] 로컬 서버에서 정상 동작을 확인했어요. (테스트 통과)
  - [x] 불필요한 코드/주석 삭제했어요.