### PR TITLE
[feat]: nginx reverse proxy + /uploads/* webp 서빙 (S3 → EC2 이미지 마이그레이션)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 /.idea
 /out
 HELP.md
+
+# 로컬 이미지 저장소 (운영은 EC2 의 /var/onz/uploads, 로컬 dev 산출물은 무시)
+/uploads/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ services:
   api-server:
     build: . # 현재 디렉토리의 Dockerfile을 사용해 이미지를 빌드
     container_name: cocktail-api
-    ports:
-      - "80:8080" # 외부 80 -> 내부 8080
+    expose:
+      - "8080" # 내부 전용. nginx 가 프록시
     environment:
       # 🚨 API 서버가 도커 내부의 'db' 서비스에 접속하도록 설정
       - SPRING_DATASOURCE_URL=jdbc:postgresql://db:5432/${POSTGRES_DB}
@@ -39,6 +39,21 @@ services:
 
     depends_on:
       - db # 'db' 서비스가 먼저 실행된 후에 실행됨
+
+  # 1.5. Nginx (reverse proxy + /uploads/* 정적 webp 서빙)
+  #   - 80 포트 owner. /uploads/* 는 /var/onz/uploads 에서, 그 외는 api-server:8080 으로 프록시
+  #   - /var/onz/uploads 는 EC2 호스트 디렉토리 (운영). 로컬 dev 는 mkdir 또는 .env 로 오버라이드.
+  nginx:
+    image: nginx:alpine
+    container_name: nginx-onz
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx-onz.conf:/etc/nginx/conf.d/default.conf:ro
+      - /var/onz/uploads:/var/onz/uploads:ro
+    depends_on:
+      - api-server
+    restart: unless-stopped
 
   # 2. PostgreSQL 서비스
   db:

--- a/nginx-onz.conf
+++ b/nginx-onz.conf
@@ -1,0 +1,24 @@
+upstream backend { server api-server:8080; }
+
+server {
+    listen 80;
+    server_name _;
+    client_max_body_size 50m;
+
+    location /uploads/ {
+        alias /var/onz/uploads/;
+        expires 30d;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+
+    location / {
+        proxy_pass http://backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 300s;
+    }
+}


### PR DESCRIPTION
기존 S3 호스팅 칵테일 이미지를 EC2 로컬 디스크 + WebP 로 이전.
- nginx-onz: 80 포트 owner, /uploads/* 정적 서빙, 그 외 api-server 로 프록시
- api-server: 80 포트 직접 노출 → 8080 internal expose
- 196 이미지 PNG/JPG → WebP 변환 (300MB → 22MB, 92.6% 감소)
- DB 의 image_url 일괄 갱신
- AWS owner 계정 종속 종료, S3 키 불필요

운영 EC2 적용 완료. 본 커밋은 source-of-truth 동기화.