### PR TITLE
fix(admin): revive prod admin dashboard (404 unblock)

### DIFF
--- a/src/main/java/com/application/domain/admin/controller/AdminViewController.java
+++ b/src/main/java/com/application/domain/admin/controller/AdminViewController.java
@@ -1,0 +1,137 @@
+package com.application.domain.admin.controller;
+
+import com.application.domain.admin.service.AdminDashboardService;
+import com.application.domain.admin.service.AdminDashboardService.DailyCount;
+import com.application.domain.admin.service.AdminDashboardService.OverviewMetrics;
+import com.application.domain.admin.service.AdminDashboardService.RecentSignup;
+import com.application.domain.admin.service.AdminDashboardService.TopCocktail;
+import com.application.domain.admin.service.AdminDashboardService.TopSearchTerm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Admin 화면 라우팅 공통 컨트롤러.
+ * Spring Security formLogin 이 /admin/login 을 loginPage 로 참조하지만
+ * 해당 뷰를 서빙하는 컨트롤러가 없었기에, 템플릿을 반환하는 최소 라우터를 추가.
+ *
+ * SecurityConfig 는 건드리지 않고 기존 체인 위에서 동작.
+ *
+ * 대시보드(/admin/dashboard)는 AdminDashboardService 를 통해 메트릭을 모델에 주입한다.
+ * Chart.js 가 차트 데이터를 그리기 위해 일부 모델 attribute 는 미리 JS-friendly 한
+ * "라벨 배열 / 값 배열" 형태로 가공해서 넘긴다.
+ */
+@Controller
+@RequestMapping("/admin")
+@RequiredArgsConstructor
+public class AdminViewController {
+
+    private static final int DAILY_RANGE_DAYS = 30;
+    private static final DateTimeFormatter DAY_LABEL = DateTimeFormatter.ofPattern("MM-dd");
+
+    private final AdminDashboardService adminDashboardService;
+
+    @GetMapping("/login")
+    public String login(@RequestParam(value = "error", required = false) String error,
+                        @RequestParam(value = "logout", required = false) String logout,
+                        Model model) {
+        if (error != null) {
+            model.addAttribute("errorMsg", "아이디 또는 비밀번호가 올바르지 않습니다.");
+        }
+        if (logout != null) {
+            model.addAttribute("logoutMsg", "로그아웃 되었습니다.");
+        }
+        return "admin/login";
+    }
+
+    @GetMapping({"", "/", "/dashboard"})
+    public String dashboard(Model model) {
+        OverviewMetrics overview = adminDashboardService.getOverviewMetrics();
+        Map<String, Long> social = adminDashboardService.getSocialLoginBreakdown();
+        List<DailyCount> dailySignups = adminDashboardService.getDailySignups(DAILY_RANGE_DAYS);
+        List<DailyCount> dailyDevices = adminDashboardService.getDailyActiveDevices(DAILY_RANGE_DAYS);
+        List<TopCocktail> topCocktails = adminDashboardService.getTopCocktails(10);
+        List<TopSearchTerm> topSearchTerms = adminDashboardService.getTopSearchTerms(10);
+        Map<String, Long> inquiryStatus = adminDashboardService.getInquiryStatusBreakdown();
+        List<RecentSignup> recentSignups = adminDashboardService.getRecentSignups(10);
+
+        model.addAttribute("overview", overview);
+        model.addAttribute("social", social);
+        model.addAttribute("topCocktails", topCocktails);
+        model.addAttribute("topSearchTerms", topSearchTerms);
+        model.addAttribute("inquiryStatus", inquiryStatus);
+        model.addAttribute("recentSignups", recentSignups);
+
+        // Chart.js 용 라벨/데이터 배열로 분리해서 주입
+        model.addAttribute("dailyLabels", buildDayLabels(dailySignups));
+        model.addAttribute("dailySignupCounts", buildCountList(dailySignups));
+        model.addAttribute("dailyDeviceCounts", buildCountList(dailyDevices));
+
+        model.addAttribute("socialLabels", new ArrayList<>(social.keySet()));
+        model.addAttribute("socialValues", new ArrayList<>(social.values()));
+
+        return "admin/dashboard";
+    }
+
+    /**
+     * AJAX 갱신용 JSON 엔드포인트. 같은 데이터를 다시 호출.
+     * 운영자가 새로고침 없이 부분 갱신할 때 사용.
+     */
+    @GetMapping("/dashboard/data")
+    @ResponseBody
+    public Map<String, Object> dashboardData() {
+        Map<String, Object> body = new HashMap<>();
+        body.put("overview", adminDashboardService.getOverviewMetrics());
+        body.put("social", adminDashboardService.getSocialLoginBreakdown());
+        body.put("dailySignups", adminDashboardService.getDailySignups(DAILY_RANGE_DAYS));
+        body.put("dailyActiveDevices", adminDashboardService.getDailyActiveDevices(DAILY_RANGE_DAYS));
+        body.put("topCocktails", adminDashboardService.getTopCocktails(10));
+        body.put("topSearchTerms", adminDashboardService.getTopSearchTerms(10));
+        body.put("inquiryStatus", adminDashboardService.getInquiryStatusBreakdown());
+        body.put("recentSignups", adminDashboardService.getRecentSignups(10));
+        return body;
+    }
+
+    @GetMapping("/cocktails")
+    public String cocktails() {
+        return "admin/cocktails";
+    }
+
+    @GetMapping("/cocktail/detail")
+    public String cocktailDetail() {
+        return "admin/cocktail/detail";
+    }
+
+    @GetMapping("/cocktail/tag")
+    public String tag() {
+        return "admin/tag";
+    }
+
+    /* ============================== helpers ============================== */
+
+    private List<String> buildDayLabels(List<DailyCount> series) {
+        List<String> labels = new ArrayList<>(series.size());
+        for (DailyCount d : series) {
+            labels.add(d.getDate().format(DAY_LABEL));
+        }
+        return labels;
+    }
+
+    private List<Long> buildCountList(List<DailyCount> series) {
+        List<Long> counts = new ArrayList<>(series.size());
+        for (DailyCount d : series) {
+            counts.add(d.getCount());
+        }
+        return counts;
+    }
+}

--- a/src/main/java/com/application/domain/admin/service/AdminDashboardService.java
+++ b/src/main/java/com/application/domain/admin/service/AdminDashboardService.java
@@ -1,0 +1,310 @@
+package com.application.domain.admin.service;
+
+import jakarta.persistence.EntityManager;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 관리자 대시보드용 집계 서비스.
+ *
+ * - 모든 데이터는 native SQL 로 조회한다. (date_trunc / generate_series 같은 PostgreSQL
+ *   전용 함수가 필요한 case 가 많아 QueryDSL 보다 native 가 명료함)
+ * - 읽기 전용 트랜잭션. DB 부하를 줄이기 위해 통계는 모두 단일 호출 단위로 캐스팅된 결과만 반환.
+ * - 데이터 누수 가능 영역(예: search_history 의 비회원 행)은 그대로 카운트한다.
+ *   "검색어 인기 순위" 는 회원/비회원 구분이 의미 없기 때문.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AdminDashboardService {
+
+    private final EntityManager em;
+
+    /* =================================================================
+     *                           Public API
+     * ================================================================= */
+
+    @Transactional(readOnly = true)
+    public OverviewMetrics getOverviewMetrics() {
+        long totalMembers = ((Number) em.createNativeQuery(
+                "SELECT COUNT(*) FROM member").getSingleResult()).longValue();
+
+        long todaySignups = ((Number) em.createNativeQuery(
+                "SELECT COUNT(*) FROM member WHERE created_at::date = CURRENT_DATE")
+                .getSingleResult()).longValue();
+
+        long last7dSignups = ((Number) em.createNativeQuery(
+                "SELECT COUNT(*) FROM member WHERE created_at >= CURRENT_DATE - INTERVAL '7 days'")
+                .getSingleResult()).longValue();
+
+        // 활성 디바이스: monitoring 테이블에 등록된 device_number distinct 카운트.
+        // monitoring.created_at/updated_at 모두 존재하지만 last_seen 의미는 약하므로
+        // "지금까지 등록된 distinct device 수" 와 "최근 7일 활성"을 분리해서 반환.
+        long activeDevicesAllTime = ((Number) em.createNativeQuery(
+                "SELECT COUNT(DISTINCT device_number) FROM monitoring")
+                .getSingleResult()).longValue();
+
+        long activeDevicesLast7d = ((Number) em.createNativeQuery(
+                "SELECT COUNT(DISTINCT device_number) FROM monitoring " +
+                "WHERE COALESCE(updated_at, created_at) >= CURRENT_DATE - INTERVAL '7 days'")
+                .getSingleResult()).longValue();
+
+        long unansweredInquiries = ((Number) em.createNativeQuery(
+                "SELECT COUNT(*) FROM inquiry WHERE status = 'NEW'")
+                .getSingleResult()).longValue();
+
+        return OverviewMetrics.builder()
+                .totalMembers(totalMembers)
+                .todaySignups(todaySignups)
+                .last7dSignups(last7dSignups)
+                .activeDevicesAllTime(activeDevicesAllTime)
+                .activeDevicesLast7d(activeDevicesLast7d)
+                .unansweredInquiries(unansweredInquiries)
+                .build();
+    }
+
+    /** 소셜 로그인 분포: { KAKAO: 8, NAVER: 2, GOOGLE: 2, APPLE: 2, UNKNOWN: 0 } */
+    @Transactional(readOnly = true)
+    public Map<String, Long> getSocialLoginBreakdown() {
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows = em.createNativeQuery(
+                "SELECT COALESCE(NULLIF(social_login, ''), 'UNKNOWN') AS social, COUNT(*) " +
+                "FROM member GROUP BY 1 ORDER BY 2 DESC").getResultList();
+
+        Map<String, Long> result = new LinkedHashMap<>();
+        for (Object[] r : rows) {
+            String key = r[0] == null ? "UNKNOWN" : r[0].toString();
+            long count = ((Number) r[1]).longValue();
+            result.put(key, count);
+        }
+        return result;
+    }
+
+    /** 최근 N일간 일별 가입자 수. 가입이 0인 날도 0 으로 채워서 반환한다. */
+    @Transactional(readOnly = true)
+    public List<DailyCount> getDailySignups(int days) {
+        int safeDays = Math.max(1, Math.min(days, 90));
+
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows = em.createNativeQuery(
+                "SELECT day::date, COUNT(m.id) " +
+                "FROM generate_series(CURRENT_DATE - (:offset || ' days')::interval, CURRENT_DATE, '1 day') AS day " +
+                "LEFT JOIN member m ON m.created_at::date = day::date " +
+                "GROUP BY day ORDER BY day")
+                .setParameter("offset", safeDays - 1)
+                .getResultList();
+
+        return toDailyCounts(rows);
+    }
+
+    /** 최근 N일간 일별 활성 디바이스 수 (해당 날짜에 monitoring 행이 created/updated 된 distinct device). */
+    @Transactional(readOnly = true)
+    public List<DailyCount> getDailyActiveDevices(int days) {
+        int safeDays = Math.max(1, Math.min(days, 90));
+
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows = em.createNativeQuery(
+                "SELECT day::date, COUNT(DISTINCT mn.device_number) " +
+                "FROM generate_series(CURRENT_DATE - (:offset || ' days')::interval, CURRENT_DATE, '1 day') AS day " +
+                "LEFT JOIN monitoring mn " +
+                "  ON COALESCE(mn.updated_at, mn.created_at)::date = day::date " +
+                "GROUP BY day ORDER BY day")
+                .setParameter("offset", safeDays - 1)
+                .getResultList();
+
+        return toDailyCounts(rows);
+    }
+
+    /**
+     * 인기 칵테일: recommend_count + bookmark 수의 합산 점수로 정렬.
+     * 현재 cocktail_bookmark 가 비어 있어도 recommend_count 만으로 동작.
+     */
+    @Transactional(readOnly = true)
+    public List<TopCocktail> getTopCocktails(int limit) {
+        int safeLimit = Math.max(1, Math.min(limit, 50));
+
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows = em.createNativeQuery(
+                "SELECT c.id, c.kor_name, c.recommend_count, c.hard_count, " +
+                "       COALESCE(b.bookmark_count, 0) AS bookmark_count, " +
+                "       (c.recommend_count + COALESCE(b.bookmark_count, 0)) AS score " +
+                "FROM cocktail c " +
+                "LEFT JOIN ( " +
+                "    SELECT cocktail_id, COUNT(*) AS bookmark_count " +
+                "    FROM cocktail_bookmark GROUP BY cocktail_id" +
+                ") b ON b.cocktail_id = c.id " +
+                "ORDER BY score DESC, c.recommend_count DESC, c.id ASC " +
+                "LIMIT :lim")
+                .setParameter("lim", safeLimit)
+                .getResultList();
+
+        List<TopCocktail> out = new ArrayList<>();
+        for (Object[] r : rows) {
+            out.add(TopCocktail.builder()
+                    .id(((Number) r[0]).longValue())
+                    .korName((String) r[1])
+                    .recommendCount(((Number) r[2]).longValue())
+                    .hardCount(((Number) r[3]).longValue())
+                    .bookmarkCount(((Number) r[4]).longValue())
+                    .score(((Number) r[5]).longValue())
+                    .build());
+        }
+        return out;
+    }
+
+    /** 인기 검색어 Top N. 회원/비회원 모두 포함. 빈 문자열/공백은 제외. */
+    @Transactional(readOnly = true)
+    public List<TopSearchTerm> getTopSearchTerms(int limit) {
+        int safeLimit = Math.max(1, Math.min(limit, 50));
+
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows = em.createNativeQuery(
+                "SELECT TRIM(query_text) AS q, COUNT(*) " +
+                "FROM search_history " +
+                "WHERE query_text IS NOT NULL AND TRIM(query_text) <> '' " +
+                "GROUP BY 1 ORDER BY 2 DESC, 1 ASC " +
+                "LIMIT :lim")
+                .setParameter("lim", safeLimit)
+                .getResultList();
+
+        List<TopSearchTerm> out = new ArrayList<>();
+        for (Object[] r : rows) {
+            out.add(new TopSearchTerm((String) r[0], ((Number) r[1]).longValue()));
+        }
+        return out;
+    }
+
+    /** 문의 상태 분포: { NEW: x, READ: y, REPLIED: z }. 없는 상태는 0 으로 채움. */
+    @Transactional(readOnly = true)
+    public Map<String, Long> getInquiryStatusBreakdown() {
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows = em.createNativeQuery(
+                "SELECT status, COUNT(*) FROM inquiry GROUP BY status").getResultList();
+
+        Map<String, Long> result = new LinkedHashMap<>();
+        result.put("NEW", 0L);
+        result.put("READ", 0L);
+        result.put("REPLIED", 0L);
+        for (Object[] r : rows) {
+            String key = r[0] == null ? "UNKNOWN" : r[0].toString();
+            long count = ((Number) r[1]).longValue();
+            result.put(key, count);
+        }
+        return result;
+    }
+
+    /** 최근 가입한 회원 N명 (닉네임/소셜/가입일). */
+    @Transactional(readOnly = true)
+    public List<RecentSignup> getRecentSignups(int limit) {
+        int safeLimit = Math.max(1, Math.min(limit, 50));
+
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows = em.createNativeQuery(
+                "SELECT id, nickname, social_login, created_at " +
+                "FROM member ORDER BY created_at DESC NULLS LAST, id DESC " +
+                "LIMIT :lim")
+                .setParameter("lim", safeLimit)
+                .getResultList();
+
+        List<RecentSignup> out = new ArrayList<>();
+        for (Object[] r : rows) {
+            LocalDateTime createdAt = null;
+            if (r[3] instanceof Timestamp ts) {
+                createdAt = ts.toLocalDateTime();
+            } else if (r[3] instanceof LocalDateTime ldt) {
+                createdAt = ldt;
+            }
+            out.add(RecentSignup.builder()
+                    .id(((Number) r[0]).longValue())
+                    .nickname((String) r[1])
+                    .socialLogin((String) r[2])
+                    .createdAt(createdAt)
+                    .build());
+        }
+        return out;
+    }
+
+    /* =================================================================
+     *                            Helpers
+     * ================================================================= */
+
+    private List<DailyCount> toDailyCounts(List<Object[]> rows) {
+        List<DailyCount> out = new ArrayList<>(rows.size());
+        for (Object[] r : rows) {
+            LocalDate date;
+            if (r[0] instanceof java.sql.Date d) {
+                date = d.toLocalDate();
+            } else if (r[0] instanceof LocalDate ld) {
+                date = ld;
+            } else if (r[0] instanceof Timestamp ts) {
+                date = ts.toLocalDateTime().toLocalDate();
+            } else {
+                date = LocalDate.parse(r[0].toString());
+            }
+            out.add(new DailyCount(date, ((Number) r[1]).longValue()));
+        }
+        return out;
+    }
+
+    /* =================================================================
+     *                              DTOs
+     * ================================================================= */
+
+    @Getter
+    @Builder
+    public static class OverviewMetrics {
+        private final long totalMembers;
+        private final long todaySignups;
+        private final long last7dSignups;
+        private final long activeDevicesAllTime;
+        private final long activeDevicesLast7d;
+        private final long unansweredInquiries;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class DailyCount {
+        private final LocalDate date;
+        private final long count;
+    }
+
+    @Getter
+    @Builder
+    public static class TopCocktail {
+        private final long id;
+        private final String korName;
+        private final long recommendCount;
+        private final long hardCount;
+        private final long bookmarkCount;
+        private final long score;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class TopSearchTerm {
+        private final String queryText;
+        private final long count;
+    }
+
+    @Getter
+    @Builder
+    public static class RecentSignup {
+        private final long id;
+        private final String nickname;
+        private final String socialLogin;
+        private final LocalDateTime createdAt;
+    }
+}

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -3,12 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <title>관리자 대시보드</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>
         body {
             font-family: 'Pretendard', sans-serif;
             background-color: #f7f9fb;
             margin: 0;
             padding: 0;
+            color: #222;
         }
         header {
             background-color: #4c7ef3;
@@ -18,10 +20,8 @@
             justify-content: space-between;
             align-items: center;
         }
-        main {
-            padding: 30px;
-        }
-        button {
+        header h2 { margin: 0; font-size: 18px; }
+        header form button {
             background: white;
             border: none;
             color: #4c7ef3;
@@ -29,9 +29,78 @@
             border-radius: 6px;
             cursor: pointer;
         }
-        button:hover {
-            background: #e8ecfc;
+        header form button:hover { background: #e8ecfc; }
+        main { padding: 24px; }
+
+        h3 { margin: 0 0 12px 0; font-size: 16px; color: #333; }
+
+        .menu-bar {
+            display: flex;
+            gap: 8px;
+            flex-wrap: wrap;
+            margin-bottom: 24px;
         }
+        .menu-bar a {
+            padding: 8px 14px;
+            background: white;
+            border: 1px solid #cdd8fa;
+            color: #4c7ef3;
+            border-radius: 6px;
+            text-decoration: none;
+            font-size: 14px;
+        }
+        .menu-bar a:hover { background: #e8ecfc; }
+
+        /* card grid */
+        .row {
+            display: grid;
+            gap: 16px;
+            margin-bottom: 20px;
+        }
+        .row.cards-4 { grid-template-columns: repeat(4, 1fr); }
+        .row.cards-3 { grid-template-columns: repeat(3, 1fr); }
+        .row.split-2 { grid-template-columns: 1fr 1fr; }
+
+        .card {
+            background: white;
+            border-radius: 8px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+            padding: 18px 20px;
+        }
+        .stat-card .label { font-size: 13px; color: #666; margin-bottom: 6px; }
+        .stat-card .value { font-size: 28px; font-weight: 700; color: #222; }
+        .stat-card .sub { font-size: 12px; color: #999; margin-top: 4px; }
+
+        .stat-card.primary .value { color: #4c7ef3; }
+        .stat-card.warn .value { color: #d93025; }
+        .stat-card.info .value { color: #137333; }
+
+        .clickable { cursor: pointer; transition: transform 0.05s; text-decoration: none; color: inherit; display: block; }
+        .clickable:hover { transform: translateY(-1px); box-shadow: 0 3px 8px rgba(0,0,0,0.08); }
+
+        table { width: 100%; border-collapse: collapse; }
+        thead { background: #f0f3fc; }
+        th, td { padding: 8px 10px; text-align: left; border-bottom: 1px solid #eef1f6; font-size: 13px; }
+        th { font-weight: 600; color: #555; }
+        tbody tr:hover { background: #fafbff; }
+
+        .empty { text-align: center; padding: 24px; color: #999; font-size: 13px; }
+        .badge {
+            display: inline-block;
+            padding: 2px 8px;
+            border-radius: 10px;
+            font-size: 11px;
+            font-weight: 600;
+            background: #e8ecfc;
+            color: #4c7ef3;
+        }
+        .badge.KAKAO   { background: #fef9c3; color: #a16207; }
+        .badge.NAVER   { background: #d1fae5; color: #047857; }
+        .badge.GOOGLE  { background: #fee2e2; color: #b91c1c; }
+        .badge.APPLE   { background: #e5e7eb; color: #1f2937; }
+        .badge.UNKNOWN { background: #f3f4f6; color: #6b7280; }
+
+        canvas { width: 100% !important; max-height: 280px; }
     </style>
 </head>
 <body>
@@ -43,11 +112,232 @@
 </header>
 
 <main>
-    <h3>관리 기능</h3>
-    <ul>
-        <li><a href="/admin/cocktails">🍸 칵테일 관리</a></li>
-        <li><a href="/admin/cocktail/tag">🏷️ 태그 관리</a></li>
-    </ul>
+    <!-- 기존 메뉴 링크 4개 유지 -->
+    <div class="menu-bar">
+        <a href="/onz/admin/cocktails">🍸 칵테일 관리</a>
+        <a href="/onz/admin/cocktail/tag">🏷️ 태그 관리</a>
+        <a href="/onz/admin/guides">📚 가이드 관리</a>
+        <a href="/onz/admin/inquiries">🗨️ 1:1 문의 관리</a>
+    </div>
+
+    <!-- Row 1: 핵심 지표 카드 4개 -->
+    <div class="row cards-4">
+        <div class="card stat-card primary">
+            <div class="label">총 회원수</div>
+            <div class="value" th:text="${overview.totalMembers}">0</div>
+            <div class="sub">전체 가입 회원 누적</div>
+        </div>
+        <div class="card stat-card">
+            <div class="label">오늘 가입</div>
+            <div class="value" th:text="${overview.todaySignups}">0</div>
+            <div class="sub">자정 기준 신규 회원</div>
+        </div>
+        <div class="card stat-card info">
+            <div class="label">7일 활성 디바이스</div>
+            <div class="value" th:text="${overview.activeDevicesLast7d}">0</div>
+            <div class="sub" th:text="'전체 등록 디바이스 ' + ${overview.activeDevicesAllTime}">전체 디바이스</div>
+        </div>
+        <a class="clickable" href="/onz/admin/inquiries?status=NEW">
+            <div class="card stat-card warn">
+                <div class="label">미답변 문의</div>
+                <div class="value" th:text="${overview.unansweredInquiries}">0</div>
+                <div class="sub">상태 NEW 인 문의 건수</div>
+            </div>
+        </a>
+    </div>
+
+    <!-- Row 2: 가입자 추이 + 소셜 분포 -->
+    <div class="row split-2">
+        <div class="card">
+            <h3>최근 30일 가입자 / 활성 디바이스</h3>
+            <canvas id="signupTrendChart"></canvas>
+        </div>
+        <div class="card">
+            <h3>소셜 로그인 비율</h3>
+            <canvas id="socialChart"></canvas>
+        </div>
+    </div>
+
+    <!-- Row 3: 인기 칵테일 + 인기 검색어 -->
+    <div class="row split-2">
+        <div class="card">
+            <h3>인기 칵테일 Top 10</h3>
+            <table>
+                <thead>
+                <tr>
+                    <th style="width:40px">#</th>
+                    <th>이름</th>
+                    <th style="width:80px">추천</th>
+                    <th style="width:80px">북마크</th>
+                    <th style="width:80px">점수</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="c, it : ${topCocktails}">
+                    <td th:text="${it.index + 1}">1</td>
+                    <td th:text="${c.korName}">칵테일</td>
+                    <td th:text="${c.recommendCount}">0</td>
+                    <td th:text="${c.bookmarkCount}">0</td>
+                    <td th:text="${c.score}">0</td>
+                </tr>
+                <tr th:if="${#lists.isEmpty(topCocktails)}">
+                    <td colspan="5" class="empty">데이터 없음</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+        <div class="card">
+            <h3>인기 검색어 Top 10</h3>
+            <table>
+                <thead>
+                <tr>
+                    <th style="width:40px">#</th>
+                    <th>검색어</th>
+                    <th style="width:80px">검색 수</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="t, it : ${topSearchTerms}">
+                    <td th:text="${it.index + 1}">1</td>
+                    <td th:text="${t.queryText}">term</td>
+                    <td th:text="${t.count}">0</td>
+                </tr>
+                <tr th:if="${#lists.isEmpty(topSearchTerms)}">
+                    <td colspan="3" class="empty">데이터 없음</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <!-- Row 4: 최근 가입자 -->
+    <div class="row">
+        <div class="card">
+            <h3>최근 가입자 10명</h3>
+            <table>
+                <thead>
+                <tr>
+                    <th style="width:60px">ID</th>
+                    <th>닉네임</th>
+                    <th style="width:120px">소셜</th>
+                    <th style="width:180px">가입일</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="m : ${recentSignups}">
+                    <td th:text="${m.id}">1</td>
+                    <td th:text="${m.nickname ?: '-'}">닉네임</td>
+                    <td>
+                        <span class="badge"
+                              th:classappend="${m.socialLogin ?: 'UNKNOWN'}"
+                              th:text="${m.socialLogin ?: 'UNKNOWN'}">KAKAO</span>
+                    </td>
+                    <td th:text="${m.createdAt != null} ? ${#temporals.format(m.createdAt, 'yyyy-MM-dd HH:mm')} : '-'">2026-04-23 10:00</td>
+                </tr>
+                <tr th:if="${#lists.isEmpty(recentSignups)}">
+                    <td colspan="4" class="empty">데이터 없음</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <!-- Row 5: 문의 상태별 카운트 -->
+    <div class="row cards-3">
+        <a class="clickable" href="/onz/admin/inquiries?status=NEW">
+            <div class="card stat-card warn">
+                <div class="label">문의 - NEW</div>
+                <div class="value" th:text="${inquiryStatus['NEW']}">0</div>
+                <div class="sub">미확인 신규 문의</div>
+            </div>
+        </a>
+        <a class="clickable" href="/onz/admin/inquiries?status=READ">
+            <div class="card stat-card">
+                <div class="label">문의 - READ</div>
+                <div class="value" th:text="${inquiryStatus['READ']}">0</div>
+                <div class="sub">확인 완료, 답변 대기</div>
+            </div>
+        </a>
+        <a class="clickable" href="/onz/admin/inquiries?status=REPLIED">
+            <div class="card stat-card info">
+                <div class="label">문의 - REPLIED</div>
+                <div class="value" th:text="${inquiryStatus['REPLIED']}">0</div>
+                <div class="sub">답변 완료</div>
+            </div>
+        </a>
+    </div>
 </main>
+
+<!-- Chart.js 데이터 주입 -->
+<script th:inline="javascript">
+    /*<![CDATA[*/
+    const dailyLabels       = /*[[${dailyLabels}]]*/ [];
+    const dailySignupCounts = /*[[${dailySignupCounts}]]*/ [];
+    const dailyDeviceCounts = /*[[${dailyDeviceCounts}]]*/ [];
+    const socialLabels      = /*[[${socialLabels}]]*/ [];
+    const socialValues      = /*[[${socialValues}]]*/ [];
+
+    // 가입/디바이스 라인 차트
+    const trendCtx = document.getElementById('signupTrendChart');
+    if (trendCtx) {
+        new Chart(trendCtx, {
+            type: 'line',
+            data: {
+                labels: dailyLabels,
+                datasets: [
+                    {
+                        label: '신규 가입',
+                        data: dailySignupCounts,
+                        borderColor: '#4c7ef3',
+                        backgroundColor: 'rgba(76,126,243,0.15)',
+                        tension: 0.3,
+                        fill: true
+                    },
+                    {
+                        label: '활성 디바이스',
+                        data: dailyDeviceCounts,
+                        borderColor: '#137333',
+                        backgroundColor: 'rgba(19,115,51,0.10)',
+                        tension: 0.3,
+                        fill: false
+                    }
+                ]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: { legend: { position: 'bottom' } },
+                scales: { y: { beginAtZero: true, ticks: { precision: 0 } } }
+            }
+        });
+    }
+
+    // 소셜 로그인 도넛
+    const socialCtx = document.getElementById('socialChart');
+    if (socialCtx) {
+        new Chart(socialCtx, {
+            type: 'doughnut',
+            data: {
+                labels: socialLabels,
+                datasets: [{
+                    data: socialValues,
+                    backgroundColor: [
+                        '#FEE500', // KAKAO
+                        '#03C75A', // NAVER
+                        '#EA4335', // GOOGLE
+                        '#000000', // APPLE
+                        '#9CA3AF'  // 기타
+                    ]
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: { legend: { position: 'bottom' } }
+            }
+        });
+    }
+    /*]]>*/
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- prod `http://onz-cocktail.kr/onz/admin/login` 이 Whitelabel **404** 로 깨져 있는 상태를 unblock 함
- 원인: dev 브랜치의 `SecurityConfig` 가 `/admin/**` 체인 + `loginPage("/admin/login")` 을 정의하지만, **해당 라우트를 처리하는 컨트롤러가 dev 에 없음**. 그래서 SecurityFilter 통과 후 라우트 매핑에서 404
- 이 PR 은 PR #116 (admin metrics dashboard) 에 들어 있던 admin 부분만 **3 파일** 로 분리해 가져옴 — inquiry/guide/image-pipeline/CI-CD 변경은 **의도적으로 제외**

## Changed
| 파일 | 내용 |
|---|---|
| `AdminViewController.java` (new) | `/admin/login`, `/admin/dashboard`, `/admin/dashboard/data` 라우터 |
| `AdminDashboardService.java` (new) | 메트릭 집계. `EntityManager` 만 의존, 외부 도메인 의존 없음 |
| `templates/admin/dashboard.html` | placeholder(53줄) → 차트/테이블 포함 본판(343줄) |

dev 의 `SecurityConfig`, `templates/admin/login.html`, static admin css/js 는 그대로 사용.

## Why minimum patch
PR #116 은 admin + inquiry + guide + image-pipeline + CI-CD 가 한 묶음이라 4289 라인 변경. 풀 머지 전까지 prod admin 만 부활시키는 게 목표.

## Test plan
- [ ] CI 그린 (compile + 기존 테스트)
- [ ] dev 머지 후 자동 CD 가 EC2 에 배포
- [ ] `http://onz-cocktail.kr/onz/admin/login` → admin 로그인 페이지 렌더 (404 아님)
- [ ] 로그인 후 `/onz/admin/dashboard` 차트 + 메트릭 표시
- [ ] PR #116 은 그대로 유지 — 추후 inquiry/guide 같이 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)